### PR TITLE
feat: Create a new disruption page - validity repeat

### DIFF
--- a/site/components/form/DateSelector.tsx
+++ b/site/components/form/DateSelector.tsx
@@ -14,6 +14,7 @@ interface DateSelectorProps<T> extends FormBase<T> {
     hiddenHint?: string;
     disablePast: boolean;
     reset?: boolean;
+    showError?: boolean;
 }
 
 const inputBox = <T extends object>(
@@ -78,6 +79,7 @@ const DateSelector = <T extends object>({
     disablePast,
     stateUpdater,
     reset = false,
+    showError = false,
 }: DateSelectorProps<T>): ReactElement => {
     const [dateValue, setDateValue] = useState<Date | null>(!!disabled || !value ? null : new Date(value));
     const [errors, setErrors] = useState<ErrorInfo[]>(initialErrors);
@@ -94,6 +96,17 @@ const DateSelector = <T extends object>({
             setDateValue(null);
         }
     }, [disabled]);
+
+    useEffect(() => {
+        if (showError) {
+            setErrors([
+                {
+                    id: inputId,
+                    errorMessage,
+                },
+            ]);
+        }
+    }, [showError, errorMessage, inputId]);
 
     return (
         <FormGroupWrapper errorIds={[inputId]} errors={errors}>

--- a/site/components/form/DateSelector.tsx
+++ b/site/components/form/DateSelector.tsx
@@ -13,6 +13,7 @@ interface DateSelectorProps<T> extends FormBase<T> {
     disabled: boolean;
     hiddenHint?: string;
     disablePast: boolean;
+    reset?: boolean;
 }
 
 const inputBox = <T extends object>(
@@ -76,9 +77,16 @@ const DateSelector = <T extends object>({
     optional = false,
     disablePast,
     stateUpdater,
+    reset = false,
 }: DateSelectorProps<T>): ReactElement => {
     const [dateValue, setDateValue] = useState<Date | null>(!!disabled || !value ? null : new Date(value));
     const [errors, setErrors] = useState<ErrorInfo[]>(initialErrors);
+
+    useEffect(() => {
+        if (reset) {
+            setDateValue(null);
+        }
+    }, [reset]);
 
     useEffect(() => {
         if (disabled) {

--- a/site/components/form/TimeSelector.tsx
+++ b/site/components/form/TimeSelector.tsx
@@ -7,6 +7,7 @@ interface TimeSelectorProps<T> extends FormBase<T> {
     disabled: boolean;
     hint?: string;
     reset?: boolean;
+    showError?: boolean;
 }
 
 const TimeSelector = <T extends object>({
@@ -22,6 +23,7 @@ const TimeSelector = <T extends object>({
     optional = false,
     stateUpdater,
     reset = false,
+    showError = false,
 }: TimeSelectorProps<T>): ReactElement => {
     const [errors, setErrors] = useState<ErrorInfo[]>(initialErrors);
     const [inputValue, setInputValue] = useState(value);
@@ -38,6 +40,17 @@ const TimeSelector = <T extends object>({
             setInputValue("");
         }
     }, [disabled]);
+
+    useEffect(() => {
+        if (showError) {
+            setErrors([
+                {
+                    id: inputId,
+                    errorMessage,
+                },
+            ]);
+        }
+    }, [showError, errorMessage, inputId]);
 
     return (
         <FormGroupWrapper errorIds={[inputId]} errors={errors}>

--- a/site/components/form/TimeSelector.tsx
+++ b/site/components/form/TimeSelector.tsx
@@ -6,6 +6,7 @@ import { handleBlur } from "../../utils/formUtils";
 interface TimeSelectorProps<T> extends FormBase<T> {
     disabled: boolean;
     hint?: string;
+    reset?: boolean;
 }
 
 const TimeSelector = <T extends object>({
@@ -20,9 +21,16 @@ const TimeSelector = <T extends object>({
     hint,
     optional = false,
     stateUpdater,
+    reset = false,
 }: TimeSelectorProps<T>): ReactElement => {
     const [errors, setErrors] = useState<ErrorInfo[]>(initialErrors);
     const [inputValue, setInputValue] = useState(value);
+
+    useEffect(() => {
+        if (reset) {
+            setInputValue("");
+        }
+    }, [reset]);
 
     useEffect(() => {
         if (disabled) {

--- a/site/pages/__snapshots__/create-disruption.test.tsx.snap
+++ b/site/pages/__snapshots__/create-disruption.test.tsx.snap
@@ -261,6 +261,47 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
           >
             When is the disruption?
           </h2>
+          <table
+            className="govuk-table"
+          >
+            <thead
+              className="govuk-table__head"
+            >
+              <tr
+                className="govuk-table__row"
+              />
+            </thead>
+            <tbody
+              className="govuk-table__body"
+            >
+              <tr
+                className="govuk-table__row"
+              >
+                <th
+                  className="govuk-table__header"
+                  scope="row"
+                >
+                  Validity period 1
+                </th>
+                <td
+                  className="govuk-table__cell"
+                >
+                  01/04/2023 0100 - 01/08/2023 0200
+                </td>
+                <td
+                  className="govuk-table__cell"
+                >
+                  <button
+                    className="govuk-link"
+                    id="1"
+                    onClick={[Function]}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
           <div
             className="govuk-form-group"
           >
@@ -495,116 +536,13 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
               </div>
             </div>
           </div>
-          <div
-            className="govuk-form-group"
+          <button
+            className="govuk-button govuk-button--secondary mt-8"
+            data-module="govuk-button"
+            onClick={[Function]}
           >
-            <fieldset
-              className="govuk-fieldset"
-              role="group"
-            >
-              <legend
-                className="govuk-fieldset__legend govuk-visually-hidden"
-              >
-                <span
-                  className="govuk-heading-s govuk-!-margin-bottom-0"
-                >
-                  Does the disruption have an end datetime?
-                </span>
-              </legend>
-              <div
-                className="govuk-checkboxes flex govuk-checkboxes--small"
-                data-module="govuk-checkboxes"
-              >
-                <div
-                  className=""
-                >
-                  <div
-                    className="govuk-checkboxes__item"
-                  >
-                    <input
-                      className="govuk-checkboxes__input"
-                      defaultChecked={false}
-                      id="disruption-no-end-date-time-noDisruptionEndDateTime"
-                      name="disruption-no-end-date-time"
-                      onChange={[Function]}
-                      type="checkbox"
-                      value="noDisruptionEndDateTime"
-                    />
-                    <label
-                      className="govuk-label govuk-checkboxes__label"
-                      htmlFor="disruption-no-end-date-time-noDisruptionEndDateTime"
-                    >
-                      No end date/time
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          </div>
-          <div
-            className="govuk-form-group"
-          >
-            <fieldset
-              className="govuk-fieldset"
-            >
-              <legend
-                className="govuk-fieldset__legend govuk-!-padding-top-6"
-              >
-                <span
-                  className="govuk-heading-s govuk-!-margin-bottom-0"
-                >
-                  Does this disruption repeat?
-                </span>
-              </legend>
-              <div
-                className=""
-              >
-                <div
-                  className="govuk-radios"
-                  id="radio-buttons"
-                >
-                  <div
-                    className="govuk-radios__item govuk-!-margin-bottom-1"
-                  >
-                    <input
-                      className="govuk-radios__input"
-                      defaultChecked={false}
-                      id="disruption-repeats-yes"
-                      name="disruption-repeats"
-                      onChange={[Function]}
-                      type="radio"
-                      value="yes"
-                    />
-                    <label
-                      className="govuk-label govuk-radios__label"
-                      htmlFor="disruption-repeats-yes"
-                    >
-                      Yes
-                    </label>
-                  </div>
-                  <div
-                    className="govuk-radios__item"
-                  >
-                    <input
-                      className="govuk-radios__input"
-                      defaultChecked={true}
-                      id="disruption-repeats-no"
-                      name="disruption-repeats"
-                      onChange={[Function]}
-                      type="radio"
-                      value="no"
-                    />
-                    <label
-                      className="govuk-label govuk-radios__label"
-                      htmlFor="disruption-repeats-no"
-                    >
-                      No
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          </div>
+            Add another validity period
+          </button>
         </div>
         <div
           className="govuk-form-group govuk-!-padding-top-3"
@@ -847,52 +785,6 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                 />
               </div>
             </div>
-          </div>
-          <div
-            className="govuk-form-group"
-          >
-            <fieldset
-              className="govuk-fieldset"
-              role="group"
-            >
-              <legend
-                className="govuk-fieldset__legend govuk-visually-hidden"
-              >
-                <span
-                  className="govuk-heading-s govuk-!-margin-bottom-0"
-                >
-                  Does the disruption have an end datetime?
-                </span>
-              </legend>
-              <div
-                className="govuk-checkboxes flex govuk-checkboxes--small"
-                data-module="govuk-checkboxes"
-              >
-                <div
-                  className=""
-                >
-                  <div
-                    className="govuk-checkboxes__item"
-                  >
-                    <input
-                      className="govuk-checkboxes__input"
-                      defaultChecked={false}
-                      id="publish-no-end-date-time-noPublishEndDateTime"
-                      name="publish-no-end-date-time"
-                      onChange={[Function]}
-                      type="checkbox"
-                      value="noPublishEndDateTime"
-                    />
-                    <label
-                      className="govuk-label govuk-checkboxes__label"
-                      htmlFor="publish-no-end-date-time-noPublishEndDateTime"
-                    >
-                      No end date/time
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
           </div>
           <button
             className="govuk-button mt-8"
@@ -1355,6 +1247,20 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
           >
             When is the disruption?
           </h2>
+          <table
+            className="govuk-table"
+          >
+            <thead
+              className="govuk-table__head"
+            >
+              <tr
+                className="govuk-table__row"
+              />
+            </thead>
+            <tbody
+              className="govuk-table__body"
+            />
+          </table>
           <div
             className="govuk-form-group"
           >
@@ -1583,116 +1489,13 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
               </div>
             </div>
           </div>
-          <div
-            className="govuk-form-group"
+          <button
+            className="govuk-button govuk-button--secondary mt-8"
+            data-module="govuk-button"
+            onClick={[Function]}
           >
-            <fieldset
-              className="govuk-fieldset"
-              role="group"
-            >
-              <legend
-                className="govuk-fieldset__legend govuk-visually-hidden"
-              >
-                <span
-                  className="govuk-heading-s govuk-!-margin-bottom-0"
-                >
-                  Does the disruption have an end datetime?
-                </span>
-              </legend>
-              <div
-                className="govuk-checkboxes flex govuk-checkboxes--small"
-                data-module="govuk-checkboxes"
-              >
-                <div
-                  className=""
-                >
-                  <div
-                    className="govuk-checkboxes__item"
-                  >
-                    <input
-                      className="govuk-checkboxes__input"
-                      defaultChecked={false}
-                      id="disruption-no-end-date-time-noDisruptionEndDateTime"
-                      name="disruption-no-end-date-time"
-                      onChange={[Function]}
-                      type="checkbox"
-                      value="noDisruptionEndDateTime"
-                    />
-                    <label
-                      className="govuk-label govuk-checkboxes__label"
-                      htmlFor="disruption-no-end-date-time-noDisruptionEndDateTime"
-                    >
-                      No end date/time
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          </div>
-          <div
-            className="govuk-form-group"
-          >
-            <fieldset
-              className="govuk-fieldset"
-            >
-              <legend
-                className="govuk-fieldset__legend govuk-!-padding-top-6"
-              >
-                <span
-                  className="govuk-heading-s govuk-!-margin-bottom-0"
-                >
-                  Does this disruption repeat?
-                </span>
-              </legend>
-              <div
-                className=""
-              >
-                <div
-                  className="govuk-radios"
-                  id="radio-buttons"
-                >
-                  <div
-                    className="govuk-radios__item govuk-!-margin-bottom-1"
-                  >
-                    <input
-                      className="govuk-radios__input"
-                      defaultChecked={false}
-                      id="disruption-repeats-yes"
-                      name="disruption-repeats"
-                      onChange={[Function]}
-                      type="radio"
-                      value="yes"
-                    />
-                    <label
-                      className="govuk-label govuk-radios__label"
-                      htmlFor="disruption-repeats-yes"
-                    >
-                      Yes
-                    </label>
-                  </div>
-                  <div
-                    className="govuk-radios__item"
-                  >
-                    <input
-                      className="govuk-radios__input"
-                      defaultChecked={true}
-                      id="disruption-repeats-no"
-                      name="disruption-repeats"
-                      onChange={[Function]}
-                      type="radio"
-                      value="no"
-                    />
-                    <label
-                      className="govuk-label govuk-radios__label"
-                      htmlFor="disruption-repeats-no"
-                    >
-                      No
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          </div>
+            Add another validity period
+          </button>
         </div>
         <div
           className="govuk-form-group govuk-!-padding-top-3"
@@ -1929,52 +1732,6 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                 />
               </div>
             </div>
-          </div>
-          <div
-            className="govuk-form-group"
-          >
-            <fieldset
-              className="govuk-fieldset"
-              role="group"
-            >
-              <legend
-                className="govuk-fieldset__legend govuk-visually-hidden"
-              >
-                <span
-                  className="govuk-heading-s govuk-!-margin-bottom-0"
-                >
-                  Does the disruption have an end datetime?
-                </span>
-              </legend>
-              <div
-                className="govuk-checkboxes flex govuk-checkboxes--small"
-                data-module="govuk-checkboxes"
-              >
-                <div
-                  className=""
-                >
-                  <div
-                    className="govuk-checkboxes__item"
-                  >
-                    <input
-                      className="govuk-checkboxes__input"
-                      defaultChecked={false}
-                      id="publish-no-end-date-time-noPublishEndDateTime"
-                      name="publish-no-end-date-time"
-                      onChange={[Function]}
-                      type="checkbox"
-                      value="noPublishEndDateTime"
-                    />
-                    <label
-                      className="govuk-label govuk-checkboxes__label"
-                      htmlFor="publish-no-end-date-time-noPublishEndDateTime"
-                    >
-                      No end date/time
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
           </div>
           <button
             className="govuk-button mt-8"

--- a/site/pages/api/create-disruption.api.ts
+++ b/site/pages/api/create-disruption.api.ts
@@ -58,14 +58,12 @@ const createDisruption = (req: NextApiRequest, res: NextApiResponse): void => {
     const disruptionStartTime = formFields["disruption-start-time"];
     const disruptionEndDate = formFields["disruption-end-date"];
     const disruptionEndTime = formFields["disruption-end-time"];
-    const disruptionIsNoEndDateTime = formFields["disruption-no-end-date-time"];
 
     validateDateTimeSection(
         disruptionStartDate,
         disruptionStartTime,
         disruptionEndDate,
         disruptionEndTime,
-        disruptionIsNoEndDateTime,
         errors,
         "some-error-id",
     );
@@ -73,14 +71,12 @@ const createDisruption = (req: NextApiRequest, res: NextApiResponse): void => {
     const publishStartTime = formFields["publish-start-time"];
     const publishEndDate = formFields["publish-end-date"];
     const publishEndTime = formFields["publish-end-time"];
-    const publishIsNoEndDateTime = formFields["publish-no-end-date-time"];
 
     validateDateTimeSection(
         publishStartDate,
         publishStartTime,
         publishEndDate,
         publishEndTime,
-        publishIsNoEndDateTime,
         errors,
         "some-error-id",
     );
@@ -97,13 +93,11 @@ const createDisruption = (req: NextApiRequest, res: NextApiResponse): void => {
         "disruption-end-date": disruptionEndDate ? getDateTime(disruptionEndDate).toString() : disruptionEndDate,
         "disruption-start-time": disruptionStartTime,
         "disruption-end-time": disruptionEndTime,
-        "disruption-no-end-date-time": disruptionIsNoEndDateTime,
         "publish-start-date": publishStartDate ? getDateTime(publishStartDate).toString() : publishStartDate,
         "publish-end-date": publishEndDate ? getDateTime(publishEndDate).toString() : publishEndDate,
         "publish-start-time": publishStartTime,
         "publish-end-time": publishEndTime,
-        "publish-no-end-date-time": publishIsNoEndDateTime,
-        "disruption-repeats": formFields["disruption-repeats"],
+        validity: [],
     };
 
     setCookieOnResponseObject(COOKIES_DISRUPTION_INFO, JSON.stringify(disruptionData), res);

--- a/site/pages/api/create-disruption.test.ts
+++ b/site/pages/api/create-disruption.test.ts
@@ -45,13 +45,11 @@ describe("createDisruption", () => {
             "disruption-end-date": disruptionEndDate,
             "disruption-start-time": "1000",
             "disruption-end-time": "1100",
-            "disruption-repeats": "no",
             "publish-start-date": publishStartDate,
             "publish-start-time": "1100",
-            "publish-end-date": "",
-            "publish-end-time": "",
-            "publish-no-end-date-time": "publishNoEndDateTime",
-            "disruption-no-end-date-time": "yes",
+            "publish-end-date": disruptionEndDate,
+            "publish-end-time": "1100",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -106,15 +104,13 @@ describe("createDisruption", () => {
             "disruption-reason": MiscellaneousReason.roadWorks,
             "disruption-start-date": disruptionStartDate,
             "disruption-start-time": "1000",
-            "disruption-end-date": "",
-            "disruption-end-time": "",
+            "disruption-end-date": publishEndDate,
+            "disruption-end-time": "1100",
             "publish-start-date": publishStartDate,
             "publish-start-time": "1100",
             "publish-end-date": publishEndDate,
             "publish-end-time": "1000",
-            "disruption-no-end-date-time": "disruptionNoEndDateTime",
-            "publish-no-end-date-time": "",
-            "disruption-repeats": "yes",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -159,11 +155,9 @@ describe("createDisruption", () => {
             "disruption-end-time": "1100",
             "publish-start-date": publishStartDate,
             "publish-start-time": "1100",
-            "publish-no-end-date-time": "publishNoEndDateTime",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-end-date": "",
-            "publish-end-time": "",
+            "publish-end-date": disruptionEndDate,
+            "publish-end-time": "1100",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -204,11 +198,9 @@ describe("createDisruption", () => {
             "disruption-end-time": "1100",
             "publish-start-date": publishStartDate,
             "publish-start-time": "1100",
-            "publish-no-end-date-time": "publishNoEndDateTime",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-end-date": "",
-            "publish-end-time": "",
+            "publish-end-date": disruptionEndDate,
+            "publish-end-time": "1100",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -235,6 +227,7 @@ describe("createDisruption", () => {
         const disruptionStartDate = dayjs().subtract(2, "day").format(CD_DATE_FORMAT).toString();
         const disruptionEndDate = dayjs().subtract(1, "day").format(CD_DATE_FORMAT).toString();
         const publishStartDate = getFutureDateAsString(12, CD_DATE_FORMAT);
+        const publishEndDate = getFutureDateAsString(15, CD_DATE_FORMAT);
 
         const disruptionData: DisruptionPageInputs = {
             "type-of-disruption": "planned",
@@ -243,17 +236,15 @@ describe("createDisruption", () => {
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
             "associated-link": "",
             "disruption-reason": MiscellaneousReason.roadWorks,
-            "disruption-start-date": disruptionStartDate.toString(),
+            "disruption-start-date": disruptionStartDate,
             "disruption-end-date": disruptionEndDate,
             "disruption-start-time": "1000",
             "disruption-end-time": "1100",
             "publish-start-date": publishStartDate,
-            "publish-start-time": "1100",
-            "publish-no-end-date-time": "publishNoEndDateTime",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-end-date": "",
-            "publish-end-time": "",
+            "publish-start-time": "1000",
+            "publish-end-date": publishEndDate,
+            "publish-end-time": "1100",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -265,14 +256,8 @@ describe("createDisruption", () => {
         disruptionData["publish-start-date"] = formatDate(publishStartDate, CD_DATE_FORMAT);
 
         const errors: ErrorInfo[] = [
-            {
-                id: "some-error-id",
-                errorMessage: "The Start date and time should be past the current date and time",
-            },
-            {
-                id: "some-error-id",
-                errorMessage: "The End date and time should be past the current date and time",
-            },
+            { id: "some-error-id", errorMessage: "The Start date and time should be past the current date and time" },
+            { id: "some-error-id", errorMessage: "The End date and time should be past the current date and time" },
         ];
         expect(setCookieSpy).toHaveBeenCalledTimes(2);
         expect(setCookieSpy).toHaveBeenNthCalledWith(1, COOKIES_DISRUPTION_INFO, expect.any(String), res);
@@ -301,9 +286,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "1100",
             "publish-end-time": "1100",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -352,9 +335,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "1100",
             "publish-end-time": "1100",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -399,9 +380,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "1100",
             "publish-end-time": "1100",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -446,9 +425,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "1100",
             "publish-end-time": "1100",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -497,9 +474,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "",
             "publish-end-time": "",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -548,9 +523,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "1000",
             "publish-end-time": "1100",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
@@ -596,9 +569,7 @@ describe("createDisruption", () => {
             "publish-end-date": publishEndDate,
             "publish-start-time": "1000",
             "publish-end-time": "1100",
-            "disruption-repeats": "yes",
-            "disruption-no-end-date-time": "",
-            "publish-no-end-date-time": "",
+            validity: [],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });

--- a/site/pages/create-disruption.page.tsx
+++ b/site/pages/create-disruption.page.tsx
@@ -44,6 +44,7 @@ export interface DisruptionPageState {
 
 const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
     const [pageState, setDisruptionPageState] = useState<DisruptionPageState>(inputs);
+    const [validityClicked, setValidityClicked] = useState(false);
 
     const updateDisruptionPageStateForInput = (
         inputName: keyof DisruptionPageInputs,
@@ -65,6 +66,7 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
 
     const addValidity = (e: SyntheticEvent) => {
         e.preventDefault();
+        setValidityClicked(true);
         if (
             pageState.inputs["disruption-start-date"] &&
             pageState.inputs["disruption-start-time"] &&
@@ -86,6 +88,7 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
                 },
                 errors: pageState.errors,
             });
+            setValidityClicked(false);
         }
     };
 
@@ -207,6 +210,7 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
                             inputName="disruption-start-date"
                             stateUpdater={stateUpdater}
                             reset={pageState.inputs["disruption-start-date"] === ""}
+                            showError={pageState.inputs["disruption-start-date"] === "" && validityClicked}
                         />
 
                         <TimeSelector<DisruptionPageInputs>
@@ -219,6 +223,7 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
                             inputName="disruption-start-time"
                             stateUpdater={stateUpdater}
                             reset={pageState.inputs["disruption-start-time"] === ""}
+                            showError={pageState.inputs["disruption-start-time"] === "" && validityClicked}
                         />
 
                         <DateSelector<DisruptionPageInputs>
@@ -232,6 +237,7 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
                             inputName="disruption-end-date"
                             stateUpdater={stateUpdater}
                             reset={pageState.inputs["disruption-end-date"] === ""}
+                            showError={pageState.inputs["disruption-end-date"] === "" && validityClicked}
                         />
 
                         <TimeSelector<DisruptionPageInputs>
@@ -244,6 +250,7 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
                             inputName="disruption-end-time"
                             stateUpdater={stateUpdater}
                             reset={pageState.inputs["disruption-end-time"] === ""}
+                            showError={pageState.inputs["disruption-end-time"] === "" && validityClicked}
                         />
                         <button
                             className="govuk-button govuk-button--secondary mt-8"

--- a/site/pages/create-disruption.page.tsx
+++ b/site/pages/create-disruption.page.tsx
@@ -66,7 +66,6 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
 
     const addValidity = (e: SyntheticEvent) => {
         e.preventDefault();
-        setValidityClicked(true);
         if (
             pageState.inputs["disruption-start-date"] &&
             pageState.inputs["disruption-start-time"] &&
@@ -89,6 +88,8 @@ const CreateDisruption = ({ inputs }: CreateDisruptionProps): ReactElement => {
                 errors: pageState.errors,
             });
             setValidityClicked(false);
+        } else {
+            setValidityClicked(true);
         }
     };
 

--- a/site/pages/create-disruption.test.tsx
+++ b/site/pages/create-disruption.test.tsx
@@ -11,17 +11,15 @@ const blankInputs: DisruptionPageState = {
         description: "",
         "associated-link": "",
         "disruption-reason": "",
-        "disruption-repeats": "no",
         "disruption-start-date": "",
         "disruption-end-date": "",
         "disruption-start-time": "",
         "disruption-end-time": "",
-        "disruption-no-end-date-time": "",
         "publish-start-date": "",
         "publish-end-date": "",
         "publish-start-time": "",
         "publish-end-time": "",
-        "publish-no-end-date-time": "",
+        validity: [],
     },
 };
 
@@ -37,13 +35,11 @@ const withInputs: DisruptionPageState = {
         "disruption-end-date": "01/08/2023",
         "disruption-start-time": "0100",
         "disruption-end-time": "0200",
-        "disruption-repeats": "no",
-        "disruption-no-end-date-time": "",
         "publish-start-date": "01/03/2023",
         "publish-end-date": "01/08/2023",
         "publish-start-time": "0200",
         "publish-end-time": "2300",
-        "publish-no-end-date-time": "",
+        validity: [{ id: 1, value: "01/04/2023 0100 - 01/08/2023 0200" }],
     },
 };
 

--- a/site/utils/apiUtils/createDisruptionValidations.ts
+++ b/site/utils/apiUtils/createDisruptionValidations.ts
@@ -215,21 +215,18 @@ export const validateDateTimeSection = (
     startTime: string,
     endDate: string,
     endTime: string,
-    isEndDateRequired: string | undefined,
     errors: ErrorInfo[],
     errorId: string,
 ) => {
     validateDateTime(startDate, startTime, errors, errorId, "Start");
-    if (!isEndDateRequired) {
-        const isValid = validateDateTime(endDate, endTime, errors, errorId, "End");
-        const jsEndDateTime: dayjs.Dayjs = getDateTime(endDate, endTime);
-        const jsStartDateTime: dayjs.Dayjs = getDateTime(startDate, startTime);
+    const isValid = validateDateTime(endDate, endTime, errors, errorId, "End");
+    const jsEndDateTime: dayjs.Dayjs = getDateTime(endDate, endTime);
+    const jsStartDateTime: dayjs.Dayjs = getDateTime(startDate, startTime);
 
-        if (isValid && jsEndDateTime.isBefore(jsStartDateTime)) {
-            errors.push({
-                id: errorId,
-                errorMessage: "End Date and time cannot be before the  Start Date and time. Update End Date and time",
-            });
-        }
+    if (isValid && jsEndDateTime.isBefore(jsStartDateTime)) {
+        errors.push({
+            id: errorId,
+            errorMessage: "End Date and time cannot be before the  Start Date and time. Update End Date and time",
+        });
     }
 };


### PR DESCRIPTION
Adding validity table and removing appropriate fields as per wireframes.

Note that this is only a front end / UI ticket and the changes made to the api will be corrected in a backend ticket (changed were only made to allow tsc checks to pass)

