### PR TITLE
Disruption info page containing changes to validity data

### DIFF
--- a/site/pages/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/__snapshots__/review-disruption.test.tsx.snap
@@ -243,34 +243,6 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   className="govuk-table__header align-middle"
                   scope="row"
                 >
-                  Validity period 2
-                </th>
-                <td
-                  className="govuk-table__cell align-middle"
-                >
-                  15/01/2022 1200 - 17/01/2022 1400
-                </td>
-                <td
-                  className="govuk-table__cell align-middle"
-                >
-                  <a
-                    className="govuk-link"
-                    href="/create-disruption"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onTouchStart={[Function]}
-                  >
-                    Change
-                  </a>
-                </td>
-              </tr>
-              <tr
-                className="govuk-table__row"
-              >
-                <th
-                  className="govuk-table__header align-middle"
-                  scope="row"
-                >
                   Publish start date
                 </th>
                 <td

--- a/site/pages/api/__snapshots__/publish.test.ts.snap
+++ b/site/pages/api/__snapshots__/publish.test.ts.snap
@@ -47,11 +47,7 @@ exports[`publish > should write the correct disruptions data to dynamoDB 1`] = `
     "TimeOfCommunication": "2023-03-03T00:00:00.000Z",
   },
   "Summary": "Some summary",
-  "ValidityPeriod": [
-    {
-      "StartTime": "2023-03-10T12:00:00.000Z",
-    },
-  ],
+  "ValidityPeriod": [],
 }
 `;
 
@@ -110,11 +106,7 @@ exports[`publish > should write the correct disruptions data to dynamoDB 2`] = `
     "TimeOfCommunication": "2023-03-03T00:00:00.000Z",
   },
   "Summary": "Some summary",
-  "ValidityPeriod": [
-    {
-      "StartTime": "2023-03-10T12:00:00.000Z",
-    },
-  ],
+  "ValidityPeriod": [],
 }
 `;
 
@@ -162,9 +154,6 @@ exports[`publish > should write the correct disruptions data to dynamoDB 3`] = `
     {
       "EndTime": "2023-03-17T17:00:00.000Z",
       "StartTime": "2023-03-10T12:00:00.000Z",
-    },
-    {
-      "StartTime": "2023-03-18T12:00:00.000Z",
     },
   ],
 }

--- a/site/pages/api/create-disruption.api.ts
+++ b/site/pages/api/create-disruption.api.ts
@@ -29,6 +29,14 @@ export const formatCreateDisruptionBody = (body: object) => {
             };
         });
 
+    validity.push({
+        disruptionStartDate: Object.values(body)[Object.keys(body).indexOf("disruptionStartDate")] as string,
+        disruptionStartTime: Object.values(body)[Object.keys(body).indexOf("disruptionStartTime")] as string,
+        disruptionEndDate: Object.values(body)[Object.keys(body).indexOf("disruptionEndDate")] as string,
+        disruptionEndTime: Object.values(body)[Object.keys(body).indexOf("disruptionEndTime")] as string,
+        disruptionNoEndDateTime: Object.values(body)[Object.keys(body).indexOf("disruptionNoEndDateTime")] as string,
+    });
+
     const cleansedBody = Object.fromEntries(
         Object.entries(body).filter((item) => !item.toString().startsWith("validity")),
     );
@@ -46,6 +54,7 @@ const createDisruption = (req: NextApiRequest, res: NextApiResponse): void => {
         const validatedBody = createDisruptionsSchemaRefined.safeParse(formattedBody);
 
         if (!validatedBody.success) {
+            formattedBody.validity.pop();
             setCookieOnResponseObject(
                 COOKIES_DISRUPTION_ERRORS,
                 JSON.stringify({

--- a/site/pages/api/create-disruption.test.ts
+++ b/site/pages/api/create-disruption.test.ts
@@ -19,12 +19,16 @@ const defaultDisruptionData = {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     associatedLink: "",
     disruptionReason: MiscellaneousReason.roadworks,
-    validity1: [defaultDisruptionStartDate, "1100", defaultDisruptionEndDate, "1000", ""],
     publishStartDate: defaultPublishStartDate,
     publishStartTime: "1100",
     publishEndDate: "",
     publishEndTime: "",
     publishNoEndDateTime: "true",
+    disruptionStartDate: defaultDisruptionStartDate,
+    disruptionStartTime: "1100",
+    disruptionEndDate: defaultDisruptionEndDate,
+    disruptionEndTime: "1000",
+    disruptionNoEndDateTime: "",
 };
 
 describe("create-disruption API", () => {
@@ -61,12 +65,20 @@ describe("create-disruption API", () => {
             { errorMessage: "Select a reason from the dropdown", id: "disruptionReason" },
             { errorMessage: "Enter a publish start date for the disruption", id: "publishStartDate" },
             { errorMessage: "Enter a publish start time for the disruption", id: "publishStartTime" },
-            { errorMessage: "At least one validity period must be provided", id: "disruptionStartDate" },
+            { errorMessage: "Enter a publish start date for the validity", id: "disruptionStartDate" },
+            { errorMessage: "Enter a publish start time for the validity", id: "disruptionStartTime" },
+            { errorMessage: "Enter a start date for the disruption", id: "disruptionStartDate" },
         ];
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
+
+        const inputs = formatCreateDisruptionBody(req.body);
+        if (inputs.validity) {
+            inputs.validity.pop();
+        }
+
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_DISRUPTION_ERRORS,
-            JSON.stringify({ inputs: formatCreateDisruptionBody(req.body), errors }),
+            JSON.stringify({ inputs: inputs, errors }),
             res,
         );
         expect(writeHeadMock).toBeCalledWith(302, { Location: "/create-disruption" });
@@ -89,10 +101,16 @@ describe("create-disruption API", () => {
             { errorMessage: "Summary must not exceed 100 characters", id: "summary" },
             { errorMessage: "Description must not exceed 500 characters", id: "description" },
         ];
+
+        const inputs = formatCreateDisruptionBody(req.body);
+        if (inputs.validity) {
+            inputs.validity.pop();
+        }
+
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_DISRUPTION_ERRORS,
-            JSON.stringify({ inputs: formatCreateDisruptionBody(req.body), errors }),
+            JSON.stringify({ inputs: inputs, errors }),
             res,
         );
         expect(writeHeadMock).toBeCalledWith(302, { Location: "/create-disruption" });
@@ -109,10 +127,14 @@ describe("create-disruption API", () => {
         createDisruption(req, res);
 
         const errors: ErrorInfo[] = [{ errorMessage: "Select a reason from the dropdown", id: "disruptionReason" }];
+        const inputs = formatCreateDisruptionBody(req.body);
+        if (inputs.validity) {
+            inputs.validity.pop();
+        }
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_DISRUPTION_ERRORS,
-            JSON.stringify({ inputs: formatCreateDisruptionBody(req.body), errors }),
+            JSON.stringify({ inputs: inputs, errors }),
             res,
         );
         expect(writeHeadMock).toBeCalledWith(302, { Location: "/create-disruption" });
@@ -128,11 +150,16 @@ describe("create-disruption API", () => {
 
         createDisruption(req, res);
 
+        const inputs = formatCreateDisruptionBody(req.body);
+        if (inputs.validity) {
+            inputs.validity.pop();
+        }
+
         const errors: ErrorInfo[] = [{ errorMessage: "Associated link must be a valid URL", id: "associatedLink" }];
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_DISRUPTION_ERRORS,
-            JSON.stringify({ inputs: formatCreateDisruptionBody(req.body), errors }),
+            JSON.stringify({ inputs: inputs, errors }),
             res,
         );
         expect(writeHeadMock).toBeCalledWith(302, { Location: "/create-disruption" });
@@ -141,18 +168,23 @@ describe("create-disruption API", () => {
     it("should redirect back to /create-disruption when validity has duplicates/overlaps", () => {
         const disruptionData = {
             ...defaultDisruptionData,
-            validity2: defaultDisruptionData.validity1,
+            validity1: [defaultDisruptionStartDate, "1100", defaultDisruptionEndDate, "1000", ""],
         };
 
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
 
         createDisruption(req, res);
 
+        const inputs = formatCreateDisruptionBody(req.body);
+        if (inputs.validity) {
+            inputs.validity.pop();
+        }
+
         const errors: ErrorInfo[] = [{ errorMessage: "Validity periods cannot overlap", id: "disruptionStartDate" }];
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_DISRUPTION_ERRORS,
-            JSON.stringify({ inputs: formatCreateDisruptionBody(req.body), errors }),
+            JSON.stringify({ inputs: inputs, errors }),
             res,
         );
         expect(writeHeadMock).toBeCalledWith(302, { Location: "/create-disruption" });
@@ -162,19 +194,23 @@ describe("create-disruption API", () => {
         const disruptionData = {
             ...defaultDisruptionData,
             validity1: ["24/03/2002", "1200", "", "", "true"],
-            validity2: defaultDisruptionData.validity1,
+            validity2: [defaultDisruptionStartDate, "1100", defaultDisruptionEndDate, "1000", ""],
         };
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
 
         createDisruption(req, res);
 
+        const inputs = formatCreateDisruptionBody(req.body);
+        if (inputs.validity) {
+            inputs.validity.pop();
+        }
         const errors: ErrorInfo[] = [
             { errorMessage: "A validity period with no end time must be the last validity", id: "disruptionStartDate" },
         ];
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_DISRUPTION_ERRORS,
-            JSON.stringify({ inputs: formatCreateDisruptionBody(req.body), errors }),
+            JSON.stringify({ inputs: inputs, errors }),
             res,
         );
         expect(writeHeadMock).toBeCalledWith(302, { Location: "/create-disruption" });

--- a/site/pages/api/publish.api.ts
+++ b/site/pages/api/publish.api.ts
@@ -59,20 +59,22 @@ const publish = async (req: NextApiRequest, res: NextApiResponse) => {
                       }
                     : {}),
             },
-            ValidityPeriod: disruptionData.validity.map((period) => ({
-                StartTime: getDatetimeFromDateAndTime(
-                    period.disruptionStartDate,
-                    period.disruptionStartTime,
-                ).toISOString(),
-                ...(period.disruptionEndDate && period.disruptionEndTime
-                    ? {
-                          EndTime: getDatetimeFromDateAndTime(
-                              period.disruptionEndDate,
-                              period.disruptionEndTime,
-                          ).toISOString(),
-                      }
-                    : {}),
-            })),
+            ValidityPeriod: disruptionData.validity
+                ? disruptionData.validity.map((period) => ({
+                      StartTime: getDatetimeFromDateAndTime(
+                          period.disruptionStartDate,
+                          period.disruptionStartTime,
+                      ).toISOString(),
+                      ...(period.disruptionEndDate && period.disruptionEndTime
+                          ? {
+                                EndTime: getDatetimeFromDateAndTime(
+                                    period.disruptionEndDate,
+                                    period.disruptionEndTime,
+                                ).toISOString(),
+                            }
+                          : {}),
+                  }))
+                : [],
             Progress: Progress.open,
             Source: {
                 SourceType: SourceType.feed,

--- a/site/pages/create-disruption.page.tsx
+++ b/site/pages/create-disruption.page.tsx
@@ -292,9 +292,10 @@ const CreateDisruption = (initialState: PageState<Partial<DisruptionPageInputs>>
                             data-module="govuk-button"
                             onClick={addValidity}
                             disabled={
-                                pageState.inputs.validity &&
-                                pageState.inputs.validity[pageState.inputs.validity.length - 1]
-                                    ?.disruptionNoEndDateTime === "true"
+                                validity.disruptionNoEndDateTime === "true" ||
+                                (pageState.inputs.validity &&
+                                    pageState.inputs.validity[pageState.inputs.validity.length - 1]
+                                        ?.disruptionNoEndDateTime === "true")
                             }
                         >
                             Add another validity period

--- a/site/pages/review-disruption.page.tsx
+++ b/site/pages/review-disruption.page.tsx
@@ -64,15 +64,17 @@ const ReviewDisruption = ({
     });
 
     const getValidityRows = () => {
-        return previousDisruptionInformation.validity.map((validity, i) => ({
-            header: `Validity period ${i + 1}`,
-            cells: [
-                validity.disruptionEndDate && validity.disruptionEndTime && !validity.disruptionNoEndDateTime
-                    ? `${validity.disruptionStartDate} ${validity.disruptionStartTime} - ${validity.disruptionEndDate} ${validity.disruptionEndTime}`
-                    : `${validity.disruptionStartDate} ${validity.disruptionStartTime} - No end date/time`,
-                createChangeLink(`validity-period-${i + 1}`, "/create-disruption"),
-            ],
-        }));
+        return previousDisruptionInformation.validity
+            ? previousDisruptionInformation.validity.map((validity, i) => ({
+                  header: `Validity period ${i + 1}`,
+                  cells: [
+                      validity.disruptionEndDate && validity.disruptionEndTime && !validity.disruptionNoEndDateTime
+                          ? `${validity.disruptionStartDate} ${validity.disruptionStartTime} - ${validity.disruptionEndDate} ${validity.disruptionEndTime}`
+                          : `${validity.disruptionStartDate} ${validity.disruptionStartTime} - No end date/time`,
+                      createChangeLink(`validity-period-${i + 1}`, "/create-disruption"),
+                  ],
+              }))
+            : [];
     };
 
     return (

--- a/site/pages/review-disruption.test.tsx
+++ b/site/pages/review-disruption.test.tsx
@@ -73,18 +73,16 @@ const previousDisruptionInformation: Disruption = {
             disruptionEndTime: "1400",
             disruptionNoEndDateTime: "",
         },
-        {
-            disruptionStartDate: "15/01/2022",
-            disruptionStartTime: "1200",
-            disruptionEndDate: "17/01/2022",
-            disruptionEndTime: "1400",
-            disruptionNoEndDateTime: "",
-        },
     ],
     publishStartDate: "13/01/2022",
     publishStartTime: "1300",
     publishEndDate: "13/01/2022",
     publishEndTime: "1400",
+    disruptionStartDate: "15/01/2022",
+    disruptionStartTime: "1200",
+    disruptionEndDate: "17/01/2022",
+    disruptionEndTime: "1400",
+    disruptionNoEndDateTime: "",
 };
 
 describe("pages", () => {

--- a/site/testData/mockData.ts
+++ b/site/testData/mockData.ts
@@ -244,16 +244,12 @@ export const disruptionInfoTestCookie: Disruption = {
     summary: "Some summary",
     associatedLink: "https://example.com",
     disruptionReason: EnvironmentReason.grassFire,
-    validity: [
-        {
-            disruptionStartDate: "10/03/2023",
-            disruptionStartTime: "1200",
-            disruptionNoEndDateTime: "true",
-        },
-    ],
     publishStartDate: "10/03/2023",
     publishStartTime: "1200",
     publishNoEndDateTime: "true",
+    disruptionStartDate: "10/03/2023",
+    disruptionStartTime: "1200",
+    disruptionNoEndDateTime: "true",
 };
 
 export const disruptionInfoMultipleValidityTestCookie: Disruption = {
@@ -268,15 +264,13 @@ export const disruptionInfoMultipleValidityTestCookie: Disruption = {
             disruptionEndDate: "17/03/2023",
             disruptionEndTime: "1700",
         },
-        {
-            disruptionStartDate: "18/03/2023",
-            disruptionStartTime: "1200",
-            disruptionNoEndDateTime: "true",
-        },
     ],
     publishStartDate: "10/03/2023",
     publishStartTime: "1200",
     publishNoEndDateTime: "true",
+    disruptionStartDate: "18/03/2023",
+    disruptionStartTime: "1200",
+    disruptionNoEndDateTime: "true",
 };
 
 export const consequenceInfoOperatorTestCookie: Consequence = {

--- a/site/utils/index.test.ts
+++ b/site/utils/index.test.ts
@@ -36,15 +36,11 @@ describe("page state from cookies test", () => {
             publishEndDate: "",
             publishEndTime: "",
             publishNoEndDateTime: "true",
-            validity: [
-                {
-                    disruptionStartDate: defaultDisruptionStartDate,
-                    disruptionEndDate: defaultDisruptionEndDate,
-                    disruptionStartTime: "1000",
-                    disruptionEndTime: "1100",
-                    disruptionNoEndDateTime: "",
-                },
-            ],
+            disruptionStartDate: defaultDisruptionStartDate,
+            disruptionEndDate: defaultDisruptionEndDate,
+            disruptionStartTime: "1000",
+            disruptionEndTime: "1100",
+            disruptionNoEndDateTime: "",
         };
 
         const parsedInput = getPageStateFromCookies(JSON.stringify(disruptionData), "", createDisruptionSchema);


### PR DESCRIPTION
Access page `/create-disruption` which should consider data in validity section when the form is submitted instead of only the added rows