### PR TITLE
Fix for issue with selecting consequence type page

### DIFF
--- a/site/pages/api/type-of-consequence.api.ts
+++ b/site/pages/api/type-of-consequence.api.ts
@@ -7,7 +7,7 @@ import {
     CREATE_CONSEQUENCE_STOPS_PATH,
     CREATE_CONSEQUENCE_SERVICES_PATH,
 } from "../../constants/index";
-import { typeOfConsequenceSchema } from "../../schemas/type-of-consequence.schema";
+import { ConsequenceType, typeOfConsequenceSchema } from "../../schemas/type-of-consequence.schema";
 import { flattenZodErrors } from "../../utils";
 import {
     destroyCookieOnResponseObject,
@@ -24,6 +24,11 @@ const addConsequence = (req: NextApiRequest, res: NextApiResponse): void => {
         const validatedBody = typeOfConsequenceSchema.safeParse(req.body);
 
         if (!validatedBody.success) {
+            const body = req.body as ConsequenceType;
+
+            if (!body.disruptionId || !body.consequenceIndex) {
+                throw new Error("No disruptionId or consequenceIndex found");
+            }
             setCookieOnResponseObject(
                 COOKIES_CONSEQUENCE_TYPE_ERRORS,
                 JSON.stringify({
@@ -32,7 +37,13 @@ const addConsequence = (req: NextApiRequest, res: NextApiResponse): void => {
                 }),
                 res,
             );
-            redirectTo(res, TYPE_OF_CONSEQUENCE_PAGE_PATH);
+
+            redirectTo(
+                res,
+                `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${body.disruptionId}/${body.consequenceIndex}${
+                    queryParam ? `?${queryParam}` : ""
+                }`,
+            );
             return;
         }
 

--- a/site/pages/api/type-of-consequence.api.ts
+++ b/site/pages/api/type-of-consequence.api.ts
@@ -26,7 +26,7 @@ const addConsequence = (req: NextApiRequest, res: NextApiResponse): void => {
         if (!validatedBody.success) {
             const body = req.body as ConsequenceType;
 
-            if (!body.disruptionId || !!body.consequenceIndex) {
+            if (!body.disruptionId || !body.consequenceIndex) {
                 throw new Error("No disruptionId or consequenceIndex found");
             }
             setCookieOnResponseObject(

--- a/site/pages/api/type-of-consequence.api.ts
+++ b/site/pages/api/type-of-consequence.api.ts
@@ -26,7 +26,7 @@ const addConsequence = (req: NextApiRequest, res: NextApiResponse): void => {
         if (!validatedBody.success) {
             const body = req.body as ConsequenceType;
 
-            if (!body.disruptionId || !body.consequenceIndex) {
+            if (!body.disruptionId || !!body.consequenceIndex) {
                 throw new Error("No disruptionId or consequenceIndex found");
             }
             setCookieOnResponseObject(

--- a/site/pages/api/type-of-consequence.test.ts
+++ b/site/pages/api/type-of-consequence.test.ts
@@ -4,7 +4,6 @@ import { randomUUID } from "crypto";
 import addConsequence from "./type-of-consequence.api";
 import { TYPE_OF_CONSEQUENCE_PAGE_PATH, COOKIES_CONSEQUENCE_TYPE_ERRORS } from "../../constants/index";
 import { ErrorInfo } from "../../interfaces";
-import { ConsequenceType } from "../../schemas/type-of-consequence.schema";
 import { getMockRequestAndResponse } from "../../testData/mockData";
 import { setCookieOnResponseObject } from "../../utils/apiUtils";
 
@@ -22,9 +21,9 @@ describe("addConsequence", () => {
 
     const disruptionId = randomUUID();
 
-    const disruptionData: ConsequenceType = {
+    const disruptionData = {
         disruptionId: disruptionId,
-        consequenceIndex: 0,
+        consequenceIndex: "0",
         consequenceType: "operatorWide",
     };
 

--- a/site/pages/api/type-of-consequence.test.ts
+++ b/site/pages/api/type-of-consequence.test.ts
@@ -20,15 +20,15 @@ describe("addConsequence", () => {
         vi.resetAllMocks();
     });
 
+    const disruptionId = randomUUID();
+
+    const disruptionData: ConsequenceType = {
+        disruptionId: disruptionId,
+        consequenceIndex: 0,
+        consequenceType: "operatorWide",
+    };
+
     it("should redirect to operator consequence page when 'Operator wide' selected", () => {
-        const disruptionId = randomUUID();
-
-        const disruptionData: ConsequenceType = {
-            disruptionId: disruptionId,
-            consequenceIndex: 0,
-            consequenceType: "operatorWide",
-        };
-
         const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
 
         addConsequence(req, res);
@@ -37,15 +37,10 @@ describe("addConsequence", () => {
     });
 
     it("should redirect to operator consequence page when 'Network wide' selected", () => {
-        const disruptionId = randomUUID();
-
-        const disruptionData: ConsequenceType = {
-            disruptionId: disruptionId,
-            consequenceIndex: 0,
-            consequenceType: "networkWide",
-        };
-
-        const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
+        const { req, res } = getMockRequestAndResponse({
+            body: { ...disruptionData, consequenceType: "networkWide" },
+            mockWriteHeadFn: writeHeadMock,
+        });
 
         addConsequence(req, res);
 
@@ -53,13 +48,12 @@ describe("addConsequence", () => {
     });
 
     it("should redirect back to add consequence page (/type-of-consequence) when no inputs are passed", () => {
-        const errors: ErrorInfo[] = [
-            { errorMessage: "Required", id: "disruptionId" },
-            { errorMessage: "Select a consequence type", id: "consequenceType" },
-            { errorMessage: "Expected number, received nan", id: "consequenceIndex" },
-        ];
+        const errors: ErrorInfo[] = [{ errorMessage: "Select a consequence type", id: "consequenceType" }];
 
-        const { req, res } = getMockRequestAndResponse({ body: {}, mockWriteHeadFn: writeHeadMock });
+        const { req, res } = getMockRequestAndResponse({
+            body: { ...disruptionData, consequenceType: "" },
+            mockWriteHeadFn: writeHeadMock,
+        });
 
         addConsequence(req, res);
 
@@ -71,19 +65,16 @@ describe("addConsequence", () => {
             res,
         );
 
-        expect(writeHeadMock).toBeCalledWith(302, { Location: TYPE_OF_CONSEQUENCE_PAGE_PATH });
+        expect(writeHeadMock).toBeCalledWith(302, { Location: `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${disruptionId}/0` });
     });
 
     it("should redirect back to add consequence page (/type-of-consequence) when incorrect values are passed", () => {
-        const disruptionData = {
-            disruptionId: randomUUID(),
-            consequenceIndex: 0,
-            consequenceType: "incorrect type",
-        };
-
         const errors: ErrorInfo[] = [{ errorMessage: "Select a consequence type", id: "consequenceType" }];
 
-        const { req, res } = getMockRequestAndResponse({ body: disruptionData, mockWriteHeadFn: writeHeadMock });
+        const { req, res } = getMockRequestAndResponse({
+            body: { ...disruptionData, consequenceType: "incorrect type" },
+            mockWriteHeadFn: writeHeadMock,
+        });
 
         addConsequence(req, res);
 
@@ -95,6 +86,6 @@ describe("addConsequence", () => {
             res,
         );
 
-        expect(writeHeadMock).toBeCalledWith(302, { Location: TYPE_OF_CONSEQUENCE_PAGE_PATH });
+        expect(writeHeadMock).toBeCalledWith(302, { Location: `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${disruptionId}/0` });
     });
 });

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -9,7 +9,11 @@ import CsrfForm from "../../components/form/CsrfForm";
 import Table from "../../components/form/Table";
 import { BaseLayout } from "../../components/layout/Layout";
 import ReviewConsequenceTable, { createChangeLink } from "../../components/ReviewConsequenceTable";
-import { TYPE_OF_CONSEQUENCE_PAGE_PATH, COOKIES_REVIEW_DISRUPTION_ERRORS } from "../../constants";
+import {
+    TYPE_OF_CONSEQUENCE_PAGE_PATH,
+    COOKIES_REVIEW_DISRUPTION_ERRORS,
+    REVIEW_DISRUPTION_PAGE_PATH,
+} from "../../constants";
 import { getDisruptionById } from "../../data/dynamo";
 import { ErrorInfo, SocialMediaPost } from "../../interfaces";
 import { Validity } from "../../schemas/create-disruption.schema";
@@ -283,7 +287,10 @@ const ReviewDisruption = ({
                         </div>
                         <Link
                             role="button"
-                            href={`${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${disruption.disruptionId}/${nextIndex}`}
+                            href={{
+                                pathname: `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${disruption.disruptionId}/${nextIndex}`,
+                                query: { return: REVIEW_DISRUPTION_PAGE_PATH },
+                            }}
                             className="govuk-button mt-2 govuk-button--secondary"
                         >
                             Add another consequence

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -1081,7 +1081,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
           </div>
           <a
             className="govuk-button mt-2 govuk-button--secondary"
-            href="/type-of-consequence/2/3"
+            href="/type-of-consequence/2/3?return=%2Freview-disruption"
             onClick={[Function]}
             onMouseEnter={[Function]}
             onTouchStart={[Function]}

--- a/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
@@ -16,7 +16,7 @@ import {
 import { getDisruptionById } from "../../../data/dynamo";
 import { PageState } from "../../../interfaces/index";
 import { ConsequenceType, typeOfConsequenceSchema } from "../../../schemas/type-of-consequence.schema";
-import { getPageState } from "../../../utils/apiUtils";
+import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getStateUpdater } from "../../../utils/formUtils";
 
 const title = "Create Consequences";
@@ -89,6 +89,8 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     if (!disruption) {
         throw new Error("Disruption not found for consequence type page");
     }
+
+    if (ctx.res) destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_TYPE_ERRORS, ctx.res);
 
     return {
         props: {


### PR DESCRIPTION
Navigate to `/type-of-consequence` page and click save without choosing an option. Appropriate error should be displayed