### PR TITLE
feat: Tooltip interactivity on map 

### DIFF
--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -394,6 +394,7 @@ const Map = ({
     }, [searchedRoutes]);
 
     const onHover = useCallback((event: MapLayerMouseEvent) => {
+        setPopupInfo({});
         const service = event.features && event.features[0];
         if (service && service.properties && service.properties.serviceId) {
             setHoverInfo({
@@ -438,7 +439,7 @@ const Map = ({
 
         [filter],
     );
-
+    console.log(popupInfo);
     const getSourcesOutbound = useCallback(
         (searchedRoutes: Partial<(Routes & { serviceId: number })[]>) =>
             searchedRoutes.map((searchedRoute) =>

--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -439,7 +439,7 @@ const Map = ({
 
         [filter],
     );
-    console.log(popupInfo);
+    
     const getSourcesOutbound = useCallback(
         (searchedRoutes: Partial<(Routes & { serviceId: number })[]>) =>
             searchedRoutes.map((searchedRoute) =>


### PR DESCRIPTION
Go to the services consequence page map and get some services / stops loaded navigate between two stops where one is above the other the tooltip should not hang