### PR TITLE
Fix for incorrect status displayed for disruptions closing within next 24 hours

### DIFF
--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -42,6 +42,7 @@ import {
     filterDatePeriodMatchesDisruptionDatePeriod,
     getDate,
     getFormattedDate,
+    dateIsSameOrBeforeSecondDate,
 } from "../utils/dates";
 
 const title = "View All Disruptions";

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -42,7 +42,6 @@ import {
     filterDatePeriodMatchesDisruptionDatePeriod,
     getDate,
     getFormattedDate,
-    dateIsSameOrBeforeSecondDate,
 } from "../utils/dates";
 
 const title = "View All Disruptions";
@@ -111,12 +110,10 @@ const getDisruptionStatus = (disruption: SortedDisruption): string => {
     const today = getDate();
     const disruptionEndDate = getSortedDisruptionFinalEndDate(disruption);
 
-    if (!!disruptionEndDate && dateIsSameOrBeforeSecondDate(disruptionEndDate, today)) {
-        if (disruptionEndDate.isBefore(today)) {
-            return "closed";
-        } else {
-            return "closing";
-        }
+    if (!!disruptionEndDate && disruptionEndDate.isBefore(today)) {
+        return "closed";
+    } else if (!!disruptionEndDate && disruptionEndDate.isBefore(today.add(24, "hours"))) {
+        return "closing";
     }
 
     return "open";


### PR DESCRIPTION
Testing instructions

- Create a new disruption with the end date and time within the next 24 hours. Navigate to view all disruptions page and the status of the disruption should be closing