### PR TITLE
fix: Image lost on page refresh error

### DIFF
--- a/site/pages/api/create-social-media-post.api.ts
+++ b/site/pages/api/create-social-media-post.api.ts
@@ -53,7 +53,12 @@ const createSocialMediaPost = async (req: NextApiRequest, res: NextApiResponse):
                 COOKIES_SOCIAL_MEDIA_ERRORS,
                 JSON.stringify({
                     inputs: fields,
-                    errors: flattenZodErrors(validatedBody.error),
+                    errors: imageFile
+                        ? [
+                              ...flattenZodErrors(validatedBody.error),
+                              { errorMessage: "Re-upload the image", id: "image" },
+                          ]
+                        : flattenZodErrors(validatedBody.error),
                 }),
                 res,
             );

--- a/site/pages/api/create-social-media-post.test.ts
+++ b/site/pages/api/create-social-media-post.test.ts
@@ -203,7 +203,10 @@ describe("create-social-media-post API", () => {
         expect(s3Spy).not.toHaveBeenCalledTimes(1);
         expect(upsertSocialMediaPostSpy).not.toHaveBeenCalledTimes(1);
 
-        const errors: ErrorInfo[] = [{ errorMessage: "Max image size is 5MB.", id: "image" }];
+        const errors: ErrorInfo[] = [
+            { errorMessage: "Max image size is 5MB.", id: "image" },
+            { errorMessage: "Re-upload the image", id: "image" },
+        ];
 
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
 
@@ -242,7 +245,10 @@ describe("create-social-media-post API", () => {
         expect(s3Spy).not.toHaveBeenCalledTimes(1);
         expect(upsertSocialMediaPostSpy).not.toHaveBeenCalledTimes(1);
 
-        const errors: ErrorInfo[] = [{ errorMessage: "Only .jpg, .jpeg and .png formats are supported.", id: "image" }];
+        const errors: ErrorInfo[] = [
+            { errorMessage: "Only .jpg, .jpeg and .png formats are supported.", id: "image" },
+            { errorMessage: "Re-upload the image", id: "image" },
+        ];
 
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
 
@@ -275,7 +281,9 @@ describe("create-social-media-post API", () => {
 
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
 
-        const errors: ErrorInfo[] = [{ errorMessage: "Publish date/time must be in the future.", id: "publishDate" }];
+        const errors: ErrorInfo[] = [
+            { errorMessage: "Publish date/time must be in the future.", id: "publishDate" },
+        ];
 
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_SOCIAL_MEDIA_ERRORS,

--- a/site/pages/api/create-social-media-post.test.ts
+++ b/site/pages/api/create-social-media-post.test.ts
@@ -281,9 +281,7 @@ describe("create-social-media-post API", () => {
 
         expect(setCookieOnResponseObject).toHaveBeenCalledTimes(1);
 
-        const errors: ErrorInfo[] = [
-            { errorMessage: "Publish date/time must be in the future.", id: "publishDate" },
-        ];
+        const errors: ErrorInfo[] = [{ errorMessage: "Publish date/time must be in the future.", id: "publishDate" }];
 
         expect(setCookieOnResponseObject).toHaveBeenCalledWith(
             COOKIES_SOCIAL_MEDIA_ERRORS,


### PR DESCRIPTION
Show an error message when an error is triggered on the page and the user had uploaded an image before. It will prompt them to upload an image again