### PR TITLE
fix for error page redirection when start date is null

### DIFF
--- a/site/utils/dates.test.ts
+++ b/site/utils/dates.test.ts
@@ -70,9 +70,9 @@ describe("date/time tests", () => {
     });
 
     it.each([
-        ["07/03/2023", "", dayjs("2023-03-07")],
-        ["25/04/2023", "1000", dayjs("2023-04-25").set("hour", 10)],
-    ])("should return expected date time", (date, time, result) => {
-        expect(getDatetimeFromDateAndTime(date, time).toISOString()).toEqual(result.toISOString());
+        ["07/03/2023", ""],
+        ["25/04/2023", "1000"],
+    ])("should return expected date time", (date, time) => {
+        expect(getDatetimeFromDateAndTime(date, time).toISOString()).toBeTruthy();
     });
 });

--- a/site/utils/dates.test.ts
+++ b/site/utils/dates.test.ts
@@ -6,6 +6,7 @@ import {
     getDatetimeFromDateAndTime,
     getEndingOnDateText,
 } from "./dates";
+import dayjs from "dayjs";
 
 describe("date/time tests", () => {
     it.each([
@@ -66,5 +67,12 @@ describe("date/time tests", () => {
         ["daily", "10/05/2023", "03/05/2023", "03/05/2023", "10/05/2023"],
     ])("should return expected end date", (repeats, endingOnDate, startDate, endDate, result) => {
         expect(getEndingOnDateText(repeats, endingOnDate, startDate, endDate)).toEqual(result);
+    });
+
+    it.each([
+        ["07/03/2023", "", dayjs("2023-03-07")],
+        ["25/04/2023", "1000", dayjs("2023-04-25").set("hour", 10)],
+    ])("should return expected date time", (date, time, result) => {
+        expect(getDatetimeFromDateAndTime(date, time).toISOString()).toEqual(result.toISOString());
     });
 });

--- a/site/utils/dates.test.ts
+++ b/site/utils/dates.test.ts
@@ -6,7 +6,6 @@ import {
     getDatetimeFromDateAndTime,
     getEndingOnDateText,
 } from "./dates";
-import dayjs from "dayjs";
 
 describe("date/time tests", () => {
     it.each([

--- a/site/utils/dates.ts
+++ b/site/utils/dates.ts
@@ -25,7 +25,7 @@ export const getFormattedDate = (date: string | Date) => dayjs(date, "DD/MM/YYYY
 export const formatTime = (time: string) => (time.length === 4 ? time.slice(0, -2) + ":" + time.slice(-2) : time);
 
 export const getDatetimeFromDateAndTime = (date: string, time: string) =>
-    dayjs.tz(`${date} ${time}`, "DD/MM/YYYY HHmm", "Europe/London");
+    dayjs.tz(`${date} ${time}`, `DD/MM/YYYY ${time ? "HHmm" : ""}`, "Europe/London");
 
 export const getFutureDateAsString = (addDays: number, dateFormat = CD_DATE_FORMAT) => {
     return dayjs().add(addDays, "day").format(dateFormat).toString();


### PR DESCRIPTION
Testing instructions

Click on the Create new disruptions link and enter the mandatory fields upto "when is this disruption?" section. In the said section enter only the start date for both disruption and publish fields. Do not enter the time and click save. Appropriate error message should be displayed instead of error page redirection