### PR TITLE
fix: Remove change link on successful social media post

### DIFF
--- a/site/pages/api/create-social-media-post.api.ts
+++ b/site/pages/api/create-social-media-post.api.ts
@@ -1,3 +1,4 @@
+import { SocialMediaPostStatus } from "@create-disruptions-data/shared-ts/enums";
 import { NextApiRequest, NextApiResponse } from "next";
 import { readFile } from "fs/promises";
 import {
@@ -82,7 +83,13 @@ const createSocialMediaPost = async (req: NextApiRequest, res: NextApiResponse):
             await putItem(process.env.IMAGE_BUCKET_NAME || "", validatedBody.data.image.key, imageContents);
         }
 
-        await upsertSocialMediaPost(validatedBody.data, session.orgId, session.isOrgStaff);
+        await upsertSocialMediaPost(
+            validatedBody.data.status === SocialMediaPostStatus.rejected
+                ? validatedBody.data
+                : { ...validatedBody.data, status: SocialMediaPostStatus.pending },
+            session.orgId,
+            session.isOrgStaff,
+        );
 
         destroyCookieOnResponseObject(COOKIES_SOCIAL_MEDIA_ERRORS, res);
 

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -73,19 +73,23 @@ const DisruptionDetail = ({
     ];
 
     const getSocialMediaRows = (post: SocialMediaPostTransformed) => {
+        const isPendingOrRejected =
+            post.status === SocialMediaPostStatus.pending || post.status === SocialMediaPostStatus.rejected;
         const socialMediaTableRows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[] = [
             {
                 header: "Message to appear",
                 cells: [
                     post.messageContent,
-                    createChangeLink(
-                        "message-to-appear",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "message-to-appear",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
@@ -98,75 +102,85 @@ const DisruptionDetail = ({
                     ) : (
                         "No image uploaded"
                     ),
-                    createChangeLink(
-                        "hootsuite-profile",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "hootsuite-profile",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Publish date",
                 cells: [
                     post.publishDate,
-                    createChangeLink(
-                        "publish-date",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "publish-date",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Publish time",
                 cells: [
                     post.publishTime,
-                    createChangeLink(
-                        "publish-time",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "publish-time",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Account name",
                 cells: [
                     post.socialAccount,
-                    createChangeLink(
-                        "account-to-publish",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "account-to-publish",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "HootSuite profile",
                 cells: [
                     post.hootsuiteProfile,
-                    createChangeLink(
-                        "hootsuite-profile",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "hootsuite-profile",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Status",
-                cells: [post.status],
+                cells: [post.status, ""],
             },
         ];
 

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -1307,6 +1307,9 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                       >
                         Pending
                       </td>
+                      <td
+                        className="govuk-table__cell align-middle"
+                      />
                     </tr>
                   </tbody>
                 </table>
@@ -1544,6 +1547,9 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                       >
                         Pending
                       </td>
+                      <td
+                        className="govuk-table__cell align-middle"
+                      />
                     </tr>
                   </tbody>
                 </table>
@@ -3104,6 +3110,9 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                       >
                         Pending
                       </td>
+                      <td
+                        className="govuk-table__cell align-middle"
+                      />
                     </tr>
                   </tbody>
                 </table>
@@ -3341,6 +3350,9 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                       >
                         Pending
                       </td>
+                      <td
+                        className="govuk-table__cell align-middle"
+                      />
                     </tr>
                   </tbody>
                 </table>

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -47,18 +47,22 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
     }>();
 
     const getSocialMediaRows = (post: SocialMediaPostTransformed) => {
+        const isPendingOrRejected =
+            post.status === SocialMediaPostStatus.pending || post.status === SocialMediaPostStatus.rejected;
         const socialMediaTableRows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[] = [
             {
                 header: "Message to appear",
                 cells: [
                     post.messageContent,
-                    createChangeLink(
-                        "message-to-appear",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "message-to-appear",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
@@ -71,70 +75,80 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
                     ) : (
                         "No image uploaded"
                     ),
-                    createChangeLink(
-                        "hootsuite-profile",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "hootsuite-profile",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Publish date",
                 cells: [
                     post.publishDate,
-                    createChangeLink(
-                        "publish-date",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "publish-date",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Publish time",
                 cells: [
                     post.publishTime,
-                    createChangeLink(
-                        "publish-time",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "publish-time",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Account name",
                 cells: [
                     post.socialAccount,
-                    createChangeLink(
-                        "account-to-publish",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "account-to-publish",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "HootSuite profile",
                 cells: [
                     post.hootsuiteProfile,
-                    createChangeLink(
-                        "hootsuite-profile",
-                        CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                        disruption,
-                        post.socialMediaPostIndex,
-                        true,
-                    ),
+                    isPendingOrRejected
+                        ? createChangeLink(
+                              "hootsuite-profile",
+                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                              disruption,
+                              post.socialMediaPostIndex,
+                              true,
+                          )
+                        : "",
                 ],
             },
             {
                 header: "Status",
-                cells: [post.status],
+                cells: [post.status, ""],
             },
         ];
 

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -1293,6 +1293,9 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         Pending
                       </td>
+                      <td
+                        className="govuk-table__cell align-middle"
+                      />
                     </tr>
                   </tbody>
                 </table>
@@ -1530,6 +1533,9 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         Pending
                       </td>
+                      <td
+                        className="govuk-table__cell align-middle"
+                      />
                     </tr>
                   </tbody>
                 </table>

--- a/site/utils/apiUtils/index.test.ts
+++ b/site/utils/apiUtils/index.test.ts
@@ -5,7 +5,6 @@ import { HOOTSUITE_URL } from "../../constants";
 import * as dynamo from "../../data/dynamo";
 import * as ssm from "../../data/ssm";
 import { DEFAULT_ORG_ID, socialMediaPostsInformation } from "../../testData/mockData";
-import * as dates from "../dates";
 import { delay, publishToHootsuite } from "./";
 
 describe("publishToHootsuite", () => {
@@ -13,12 +12,12 @@ describe("publishToHootsuite", () => {
         vi.resetAllMocks();
     });
 
-    vi.mock("../../utils/apiUtils", async () => ({
-        ...(await vi.importActual<object>("../../utils/apiUtils")),
+    vi.mock("dayjs", async () => ({
+        ...(await vi.importActual<object>("dayjs")),
     }));
 
-    vi.mock("../dates", () => ({
-        formatDate: vi.fn(),
+    vi.mock("../../utils/apiUtils", async () => ({
+        ...(await vi.importActual<object>("../../utils/apiUtils")),
     }));
 
     vi.mock("../../data/ssm", () => ({
@@ -41,7 +40,6 @@ describe("publishToHootsuite", () => {
     const getParameterSpy = vi.spyOn(ssm, "getParameter");
     const getParametersByPathSpy = vi.spyOn(ssm, "getParametersByPath");
     const putParameterSpy = vi.spyOn(ssm, "putParameter");
-    const formatDateSpy = vi.spyOn(dates, "formatDate");
 
     it("should return successfully after publishing pending social media post to hootsuite", async () => {
         getParametersByPathSpy.mockResolvedValue({
@@ -112,7 +110,6 @@ describe("publishToHootsuite", () => {
         putParameterSpy.mockResolvedValueOnce();
         putParameterSpy.mockResolvedValueOnce();
         readFileSpy.mockResolvedValue(buffer);
-        formatDateSpy.mockImplementation(() => "2023-06-20T19:05:00.000Z");
 
         global.fetch = vi
             .fn()

--- a/site/utils/dates.ts
+++ b/site/utils/dates.ts
@@ -15,7 +15,8 @@ dayjs.extend(isBetween);
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-export const formatDate = (date: string, time: string) => dayjs(`${date} ${time}`, "DD/MM/YYYY HHmm").toISOString();
+export const formatDate = (date: string, time: string) =>
+    dayjs(`${date} ${time}`, "DD/MM/YYYY HHmm").tz("Europe/London").toISOString();
 
 export const convertDateTimeToFormat = (dateOrTime: string | Date, format: string = CD_DATE_FORMAT) => {
     return dayjs(dateOrTime).tz("Europe/London").format(format);

--- a/site/utils/dates.ts
+++ b/site/utils/dates.ts
@@ -16,7 +16,7 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 export const formatDate = (date: string, time: string) =>
-    dayjs(`${date} ${time}`, "DD/MM/YYYY HHmm").tz("Europe/London").toISOString();
+    dayjs.tz(`${date} ${time}`, "DD/MM/YYYY HHmm", "Europe/London").utc().toISOString();
 
 export const convertDateTimeToFormat = (dateOrTime: string | Date, format: string = CD_DATE_FORMAT) => {
     return dayjs(dateOrTime).tz("Europe/London").format(format);


### PR DESCRIPTION
And if disruption is rejected but then editing it becomes pending so you can publish again
And on test the time for a post is scheduled one hour ahead of dev