### PR TITLE
Allow org admins to toggle source data between tnds and bods

### DIFF
--- a/shared-ts/enums.ts
+++ b/shared-ts/enums.ts
@@ -176,3 +176,8 @@ export enum SocialMediaPostStatus {
     successful = "Successful",
     rejected = "Rejected",
 }
+
+export enum Modes {
+    tnds = "tnds",
+    bods = "bods",
+}

--- a/site/components/form/SearchSelect.tsx
+++ b/site/components/form/SearchSelect.tsx
@@ -23,7 +23,7 @@ interface SearchSelectProps<T> {
     inputId: string;
     hint?: string;
     isClearable?: boolean;
-    options: T[] | undefined;
+    options: T[] | undefined | null;
     inputValue: string;
     setSearchInput: Dispatch<SetStateAction<string>>;
     filterOptions?: (option: FilterOptionOption<object>, rawInput: string) => boolean;

--- a/site/components/form/SearchSelect.tsx
+++ b/site/components/form/SearchSelect.tsx
@@ -23,7 +23,7 @@ interface SearchSelectProps<T> {
     inputId: string;
     hint?: string;
     isClearable?: boolean;
-    options: T[] | undefined | null;
+    options: T[] | undefined;
     inputValue: string;
     setSearchInput: Dispatch<SetStateAction<string>>;
     filterOptions?: (option: FilterOptionOption<object>, rawInput: string) => boolean;

--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -29,7 +29,11 @@ import {
 } from "../../schemas/consequence.schema";
 import { flattenZodErrors } from "../../utils";
 import { getStopType, sortStops } from "../../utils/formUtils";
+import { Modes } from "@create-disruptions-data/shared-ts/enums";
 
+interface ServiceMapProps extends MapProps {
+    dataSource?: Modes;
+}
 interface MapProps {
     initialViewState: Partial<ViewState>;
     style: CSSProperties;
@@ -41,7 +45,7 @@ interface MapProps {
     stateUpdater: Dispatch<SetStateAction<PageState<Partial<ServicesConsequence>>>>;
     state: PageState<Partial<ServicesConsequence>>;
     searchedRoutes?: Partial<(Routes & { serviceId: number })[]>;
-    services?: Service[];
+    services?: Service[] | null;
 }
 
 const lineLayout: LineLayout = {
@@ -77,7 +81,8 @@ const Map = ({
     state,
     searchedRoutes,
     services,
-}: MapProps): ReactElement | null => {
+    dataSource,
+}: ServiceMapProps): ReactElement | null => {
     const mapboxAccessToken = process.env.MAP_BOX_ACCESS_TOKEN;
     const [features, setFeatures] = useState<{ [key: string]: PolygonFeature }>({});
     const [markerData, setMarkerData] = useState<Stop[]>([]);
@@ -239,7 +244,9 @@ const Map = ({
                     if (showSelectAllText) {
                         const atcoCodes = markerData.map((marker) => marker.atcoCode);
 
-                        const servicesInPolygon = await fetchServicesByStops({ atcoCodes, includeRoutes: true });
+                        const servicesInPolygon = dataSource
+                            ? await fetchServicesByStops({ atcoCodes, includeRoutes: true, dataSource: dataSource })
+                            : await fetchServicesByStops({ atcoCodes, includeRoutes: true });
 
                         const servicesStopsInPolygon = servicesInPolygon.flatMap((service) => service.stops);
                         const markerDataInAService = markerData

--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -1,3 +1,4 @@
+import { Modes } from "@create-disruptions-data/shared-ts/enums";
 import { Feature, GeoJsonProperties, Geometry } from "geojson";
 import { LineLayout, LinePaint, MapLayerMouseEvent } from "mapbox-gl";
 import {
@@ -29,7 +30,6 @@ import {
 } from "../../schemas/consequence.schema";
 import { flattenZodErrors } from "../../utils";
 import { getStopType, sortStops } from "../../utils/formUtils";
-import { Modes } from "@create-disruptions-data/shared-ts/enums";
 
 interface ServiceMapProps extends MapProps {
     dataSource?: Modes;

--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -45,7 +45,7 @@ interface MapProps {
     stateUpdater: Dispatch<SetStateAction<PageState<Partial<ServicesConsequence>>>>;
     state: PageState<Partial<ServicesConsequence>>;
     searchedRoutes?: Partial<(Routes & { serviceId: number })[]>;
-    services?: Service[] | null;
+    services?: Service[];
 }
 
 const lineLayout: LineLayout = {

--- a/site/data/dynamo.ts
+++ b/site/data/dynamo.ts
@@ -580,6 +580,20 @@ export const removeConsequenceFromDisruption = async (index: number, disruptionI
     );
 };
 
+export const upsertOrganisation = async (orgId: string, organisation: Organisation) => {
+    logger.info(`Updating organisation (${organisation.name}) in DynamoDB table...`);
+
+    await ddbDocClient.send(
+        new PutCommand({
+            TableName: organisationsTableName,
+            Item: {
+                PK: orgId,
+                ...organisation,
+            },
+        }),
+    );
+};
+
 export const removeOrganisation = async (orgId: string) => {
     logger.info(`Deleting organisation (${orgId}) in DynamoDB table...`);
 

--- a/site/data/refDataApi.ts
+++ b/site/data/refDataApi.ts
@@ -1,3 +1,4 @@
+import { Modes } from "@create-disruptions-data/shared-ts/enums";
 import { Position } from "geojson";
 import { z } from "zod";
 import { API_BASE_URL } from "../constants";
@@ -43,6 +44,7 @@ export const fetchStops = async (input: FetchStopsInput) => {
 
 interface FetchServicesInput {
     adminAreaCodes?: string[];
+    dataSource?: Modes;
 }
 
 export const fetchServices = async (input: FetchServicesInput) => {
@@ -52,6 +54,10 @@ export const fetchServices = async (input: FetchServicesInput) => {
 
     if (input.adminAreaCodes && input.adminAreaCodes.length > 0) {
         queryStringItems.push(`adminAreaCodes=${input.adminAreaCodes.join(",")}`);
+    }
+
+    if (input.dataSource) {
+        queryStringItems.push(`dataSource=${input.dataSource}`);
     }
 
     const res = await fetch(`${searchApiUrl}${queryStringItems.length > 0 ? `?${queryStringItems.join("&")}` : ""}`, {
@@ -70,6 +76,7 @@ export const fetchServices = async (input: FetchServicesInput) => {
 interface FetchServicesByStopsInput {
     atcoCodes?: string[];
     includeRoutes?: boolean;
+    dataSource?: Modes;
 }
 
 export const fetchServicesByStops = async (input: FetchServicesByStopsInput) => {
@@ -83,6 +90,10 @@ export const fetchServicesByStops = async (input: FetchServicesByStopsInput) => 
 
     if (input.includeRoutes) {
         queryStringItems.push("includeRoutes=true");
+    }
+
+    if (input.dataSource) {
+        queryStringItems.push(`dataSource=${input.dataSource}`);
     }
 
     const res = await fetch(`${searchApiUrl}${queryStringItems.length > 0 ? `?${queryStringItems.join("&")}` : ""}`, {

--- a/site/interfaces/index.ts
+++ b/site/interfaces/index.ts
@@ -68,7 +68,8 @@ export interface PageState<T> {
 }
 
 export interface CreateConsequenceProps {
-    initialServices?: Service[];
+    initialBodsServices?: Service[] | null;
+    initialTndsServices?: Service[] | null;
     initialStops?: Stop[];
 }
 

--- a/site/interfaces/index.ts
+++ b/site/interfaces/index.ts
@@ -68,8 +68,8 @@ export interface PageState<T> {
 }
 
 export interface CreateConsequenceProps {
-    initialBodsServices?: Service[] | null;
-    initialTndsServices?: Service[] | null;
+    initialBodsServices?: Service[];
+    initialTndsServices?: Service[];
     initialStops?: Stop[];
 }
 

--- a/site/pages/__snapshots__/account-settings.test.tsx.snap
+++ b/site/pages/__snapshots__/account-settings.test.tsx.snap
@@ -50,7 +50,9 @@ exports[`accountSettings > should render correctly 1`] = `
         <div
           className="govuk-grid-column-two-thirds"
         >
-          <div>
+          <div
+            className="govuk-form-group"
+          >
             <h1
               className="govuk-heading-l"
             >
@@ -160,6 +162,254 @@ exports[`accountSettings > should render correctly 1`] = `
                   <td
                     className="govuk-table__cell align-middle"
                   />
+                </tr>
+              </tbody>
+            </table>
+            <h2
+              className="govuk-heading-m"
+            >
+              From which source shall we acquire your data
+            </h2>
+            <table
+              className="govuk-table"
+            >
+              <thead
+                className="govuk-table__head"
+              >
+                <tr
+                  className="govuk-table__row"
+                />
+              </thead>
+              <tbody
+                className="govuk-table__body"
+              >
+                <tr
+                  className="govuk-table__row"
+                >
+                  <th
+                    className="govuk-table__header align-middle"
+                    scope="row"
+                  >
+                    Bus
+                  </th>
+                  <td
+                    className="govuk-table__cell align-middle"
+                  >
+                    <div
+                      className="govuk-radios govuk-radios--inline"
+                      data-module="govuk-radios"
+                    >
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={false}
+                          className="govuk-radios__input"
+                          id="bus-tnds"
+                          name="bus-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="tnds"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="bus-tnds"
+                        >
+                          TNDS
+                        </label>
+                      </div>
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={true}
+                          className="govuk-radios__input"
+                          id="bus-bods"
+                          name="bus-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="bods"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="bus-bods"
+                        >
+                          BODS
+                        </label>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="govuk-table__row"
+                >
+                  <th
+                    className="govuk-table__header align-middle"
+                    scope="row"
+                  >
+                    Tram
+                  </th>
+                  <td
+                    className="govuk-table__cell align-middle"
+                  >
+                    <div
+                      className="govuk-radios govuk-radios--inline"
+                      data-module="govuk-radios"
+                    >
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={false}
+                          className="govuk-radios__input"
+                          id="tram-tnds"
+                          name="tram-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="tnds"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="tram-tnds"
+                        >
+                          TNDS
+                        </label>
+                      </div>
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={true}
+                          className="govuk-radios__input"
+                          id="tram-bods"
+                          name="tram-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="bods"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="tram-bods"
+                        >
+                          BODS
+                        </label>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="govuk-table__row"
+                >
+                  <th
+                    className="govuk-table__header align-middle"
+                    scope="row"
+                  >
+                    Ferry
+                  </th>
+                  <td
+                    className="govuk-table__cell align-middle"
+                  >
+                    <div
+                      className="govuk-radios govuk-radios--inline"
+                      data-module="govuk-radios"
+                    >
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={false}
+                          className="govuk-radios__input"
+                          id="ferry-tnds"
+                          name="ferry-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="tnds"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="ferry-tnds"
+                        >
+                          TNDS
+                        </label>
+                      </div>
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={true}
+                          className="govuk-radios__input"
+                          id="ferry-bods"
+                          name="ferry-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="bods"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="ferry-bods"
+                        >
+                          BODS
+                        </label>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  className="govuk-table__row"
+                >
+                  <th
+                    className="govuk-table__header align-middle"
+                    scope="row"
+                  >
+                    Rail
+                  </th>
+                  <td
+                    className="govuk-table__cell align-middle"
+                  >
+                    <div
+                      className="govuk-radios govuk-radios--inline"
+                      data-module="govuk-radios"
+                    >
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={false}
+                          className="govuk-radios__input"
+                          id="rail-tnds"
+                          name="rail-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="tnds"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="rail-tnds"
+                        >
+                          TNDS
+                        </label>
+                      </div>
+                      <div
+                        className="govuk-radios__item"
+                      >
+                        <input
+                          checked={true}
+                          className="govuk-radios__input"
+                          id="rail-bods"
+                          name="rail-group"
+                          onChange={[Function]}
+                          type="radio"
+                          value="bods"
+                        />
+                        <label
+                          className="govuk-label govuk-radios__label"
+                          htmlFor="rail-bods"
+                        >
+                          BODS
+                        </label>
+                      </div>
+                    </div>
+                  </td>
                 </tr>
               </tbody>
             </table>

--- a/site/pages/__snapshots__/account-settings.test.tsx.snap
+++ b/site/pages/__snapshots__/account-settings.test.tsx.snap
@@ -310,7 +310,7 @@ exports[`accountSettings > should render correctly 1`] = `
                         className="govuk-table__header align-middle"
                         scope="row"
                       >
-                        FerryService
+                        Ferry
                       </th>
                       <td
                         className="govuk-table__cell align-middle"

--- a/site/pages/__snapshots__/account-settings.test.tsx.snap
+++ b/site/pages/__snapshots__/account-settings.test.tsx.snap
@@ -170,249 +170,257 @@ exports[`accountSettings > should render correctly 1`] = `
             >
               From which source shall we acquire your data
             </h2>
-            <table
-              className="govuk-table"
+            <div
+              className="govuk-form-group"
             >
-              <thead
-                className="govuk-table__head"
+              <div
+                className=""
               >
-                <tr
-                  className="govuk-table__row"
-                />
-              </thead>
-              <tbody
-                className="govuk-table__body"
-              >
-                <tr
-                  className="govuk-table__row"
+                <table
+                  className="govuk-table"
                 >
-                  <th
-                    className="govuk-table__header align-middle"
-                    scope="row"
+                  <thead
+                    className="govuk-table__head"
                   >
-                    Bus
-                  </th>
-                  <td
-                    className="govuk-table__cell align-middle"
+                    <tr
+                      className="govuk-table__row"
+                    />
+                  </thead>
+                  <tbody
+                    className="govuk-table__body"
                   >
-                    <div
-                      className="govuk-radios govuk-radios--inline"
-                      data-module="govuk-radios"
+                    <tr
+                      className="govuk-table__row"
                     >
-                      <div
-                        className="govuk-radios__item"
+                      <th
+                        className="govuk-table__header align-middle"
+                        scope="row"
                       >
-                        <input
-                          checked={false}
-                          className="govuk-radios__input"
-                          id="bus-tnds"
-                          name="bus-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="tnds"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="bus-tnds"
-                        >
-                          TNDS
-                        </label>
-                      </div>
-                      <div
-                        className="govuk-radios__item"
+                        Bus
+                      </th>
+                      <td
+                        className="govuk-table__cell align-middle"
                       >
-                        <input
-                          checked={true}
-                          className="govuk-radios__input"
-                          id="bus-bods"
-                          name="bus-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="bods"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="bus-bods"
+                        <div
+                          className="govuk-radios govuk-radios--inline"
+                          data-module="govuk-radios"
                         >
-                          BODS
-                        </label>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="govuk-table__row"
-                >
-                  <th
-                    className="govuk-table__header align-middle"
-                    scope="row"
-                  >
-                    Tram
-                  </th>
-                  <td
-                    className="govuk-table__cell align-middle"
-                  >
-                    <div
-                      className="govuk-radios govuk-radios--inline"
-                      data-module="govuk-radios"
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={false}
+                              className="govuk-radios__input"
+                              id="bus-tnds"
+                              name="bus-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="tnds"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="bus-tnds"
+                            >
+                              TNDS
+                            </label>
+                          </div>
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={true}
+                              className="govuk-radios__input"
+                              id="bus-bods"
+                              name="bus-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="bods"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="bus-bods"
+                            >
+                              BODS
+                            </label>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      className="govuk-table__row"
                     >
-                      <div
-                        className="govuk-radios__item"
+                      <th
+                        className="govuk-table__header align-middle"
+                        scope="row"
                       >
-                        <input
-                          checked={false}
-                          className="govuk-radios__input"
-                          id="tram-tnds"
-                          name="tram-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="tnds"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="tram-tnds"
-                        >
-                          TNDS
-                        </label>
-                      </div>
-                      <div
-                        className="govuk-radios__item"
+                        Tram
+                      </th>
+                      <td
+                        className="govuk-table__cell align-middle"
                       >
-                        <input
-                          checked={true}
-                          className="govuk-radios__input"
-                          id="tram-bods"
-                          name="tram-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="bods"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="tram-bods"
+                        <div
+                          className="govuk-radios govuk-radios--inline"
+                          data-module="govuk-radios"
                         >
-                          BODS
-                        </label>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="govuk-table__row"
-                >
-                  <th
-                    className="govuk-table__header align-middle"
-                    scope="row"
-                  >
-                    Ferry
-                  </th>
-                  <td
-                    className="govuk-table__cell align-middle"
-                  >
-                    <div
-                      className="govuk-radios govuk-radios--inline"
-                      data-module="govuk-radios"
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={false}
+                              className="govuk-radios__input"
+                              id="tram-tnds"
+                              name="tram-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="tnds"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="tram-tnds"
+                            >
+                              TNDS
+                            </label>
+                          </div>
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={true}
+                              className="govuk-radios__input"
+                              id="tram-bods"
+                              name="tram-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="bods"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="tram-bods"
+                            >
+                              BODS
+                            </label>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      className="govuk-table__row"
                     >
-                      <div
-                        className="govuk-radios__item"
+                      <th
+                        className="govuk-table__header align-middle"
+                        scope="row"
                       >
-                        <input
-                          checked={false}
-                          className="govuk-radios__input"
-                          id="ferry-tnds"
-                          name="ferry-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="tnds"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="ferry-tnds"
-                        >
-                          TNDS
-                        </label>
-                      </div>
-                      <div
-                        className="govuk-radios__item"
+                        FerryService
+                      </th>
+                      <td
+                        className="govuk-table__cell align-middle"
                       >
-                        <input
-                          checked={true}
-                          className="govuk-radios__input"
-                          id="ferry-bods"
-                          name="ferry-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="bods"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="ferry-bods"
+                        <div
+                          className="govuk-radios govuk-radios--inline"
+                          data-module="govuk-radios"
                         >
-                          BODS
-                        </label>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  className="govuk-table__row"
-                >
-                  <th
-                    className="govuk-table__header align-middle"
-                    scope="row"
-                  >
-                    Rail
-                  </th>
-                  <td
-                    className="govuk-table__cell align-middle"
-                  >
-                    <div
-                      className="govuk-radios govuk-radios--inline"
-                      data-module="govuk-radios"
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={false}
+                              className="govuk-radios__input"
+                              id="ferryService-tnds"
+                              name="ferryService-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="tnds"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="ferryService-tnds"
+                            >
+                              TNDS
+                            </label>
+                          </div>
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={true}
+                              className="govuk-radios__input"
+                              id="ferryService-bods"
+                              name="ferryService-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="bods"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="ferryService-bods"
+                            >
+                              BODS
+                            </label>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr
+                      className="govuk-table__row"
                     >
-                      <div
-                        className="govuk-radios__item"
+                      <th
+                        className="govuk-table__header align-middle"
+                        scope="row"
                       >
-                        <input
-                          checked={false}
-                          className="govuk-radios__input"
-                          id="rail-tnds"
-                          name="rail-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="tnds"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="rail-tnds"
-                        >
-                          TNDS
-                        </label>
-                      </div>
-                      <div
-                        className="govuk-radios__item"
+                        Rail
+                      </th>
+                      <td
+                        className="govuk-table__cell align-middle"
                       >
-                        <input
-                          checked={true}
-                          className="govuk-radios__input"
-                          id="rail-bods"
-                          name="rail-group"
-                          onChange={[Function]}
-                          type="radio"
-                          value="bods"
-                        />
-                        <label
-                          className="govuk-label govuk-radios__label"
-                          htmlFor="rail-bods"
+                        <div
+                          className="govuk-radios govuk-radios--inline"
+                          data-module="govuk-radios"
                         >
-                          BODS
-                        </label>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={false}
+                              className="govuk-radios__input"
+                              id="rail-tnds"
+                              name="rail-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="tnds"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="rail-tnds"
+                            >
+                              TNDS
+                            </label>
+                          </div>
+                          <div
+                            className="govuk-radios__item"
+                          >
+                            <input
+                              checked={true}
+                              className="govuk-radios__input"
+                              id="rail-bods"
+                              name="rail-group"
+                              onChange={[Function]}
+                              type="radio"
+                              value="bods"
+                            />
+                            <label
+                              className="govuk-label govuk-radios__label"
+                              htmlFor="rail-bods"
+                            >
+                              BODS
+                            </label>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/site/pages/account-settings.page.tsx
+++ b/site/pages/account-settings.page.tsx
@@ -1,8 +1,10 @@
+import { Modes } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 import Table from "../components/form/Table";
 import { TwoThirdsLayout } from "../components/layout/Layout";
+import { ModeType } from "../schemas/organisation.schema";
 import { SessionWithOrgDetail } from "../schemas/session.schema";
 import { getSessionWithOrgDetail } from "../utils/apiUtils/auth";
 
@@ -11,40 +13,119 @@ const description = "Account settings page for the Create Transport Disruption D
 
 interface AccountSettingsProps {
     sessionWithOrg: SessionWithOrgDetail;
+    csrfToken?: string;
 }
 
-const AccountSettings = ({ sessionWithOrg }: AccountSettingsProps): ReactElement => (
-    <TwoThirdsLayout title={title} description={description}>
-        <div>
-            <h1 className="govuk-heading-l">My account</h1>
-            <h2 className="govuk-heading-m">Account settings</h2>
-            <Table
-                rows={[
-                    { header: "Email address", cells: [sessionWithOrg.email, ""] },
-                    {
-                        header: "Password",
-                        cells: [
-                            <input
-                                className="bg-white"
-                                disabled={true}
-                                key="password"
-                                type="password"
-                                id="password"
-                                name="password"
-                                value={"myPassword"}
-                            />,
-                            <Link key={"change-password"} className="govuk-link" href={"/change-password"}>
-                                Change
-                            </Link>,
-                        ],
-                    },
-                    { header: "Organisation", cells: [sessionWithOrg.orgName, ""] },
-                    { header: "NaPTAN Adminarea", cells: [sessionWithOrg?.adminAreaCodes.join(", "), ""] },
-                ]}
-            />
-        </div>
-    </TwoThirdsLayout>
-);
+const AccountSettings = ({ sessionWithOrg, csrfToken }: AccountSettingsProps): ReactElement => {
+    const [mode, setMode] = useState<ModeType>(sessionWithOrg.mode as ModeType);
+
+    const updateOrg = async (key: string, value: Modes) => {
+        const previousValue = mode[key as keyof ModeType];
+        setMode({ ...mode, [key]: value });
+        const url = new URL("/api/admin/update-org", window.location.origin);
+        csrfToken ? url.searchParams.append("_csrf", csrfToken) : null;
+        const res = await fetch(url.toString(), {
+            method: "POST",
+            headers: csrfToken
+                ? {
+                      "Content-Type": "application/json",
+                      "X-CSRF-TOKEN": csrfToken,
+                  }
+                : { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                PK: sessionWithOrg.orgId,
+                adminAreaCodes: sessionWithOrg.adminAreaCodes,
+                mode: { ...mode, [key]: value },
+                name: sessionWithOrg.name,
+            }),
+        });
+
+        !res.ok ? setMode({ ...mode, [key]: previousValue }) : null;
+    };
+
+    return (
+        <TwoThirdsLayout title={title} description={description}>
+            <div className="govuk-form-group">
+                <h1 className="govuk-heading-l">My account</h1>
+                <h2 className="govuk-heading-m">Account settings</h2>
+                <Table
+                    rows={[
+                        { header: "Email address", cells: [sessionWithOrg.email, ""] },
+                        {
+                            header: "Password",
+                            cells: [
+                                <input
+                                    className="bg-white"
+                                    disabled={true}
+                                    key="password"
+                                    type="password"
+                                    id="password"
+                                    name="password"
+                                    value={"myPassword"}
+                                />,
+                                <Link key={"change-password"} className="govuk-link" href={"/change-password"}>
+                                    Change
+                                </Link>,
+                            ],
+                        },
+                        { header: "Organisation", cells: [sessionWithOrg.orgName, ""] },
+                        { header: "NaPTAN Adminarea", cells: [sessionWithOrg?.adminAreaCodes.join(", "), ""] },
+                    ]}
+                />
+                {sessionWithOrg.isOrgAdmin ? (
+                    <>
+                        <h2 className="govuk-heading-m">From which source shall we acquire your data</h2>
+                        <Table
+                            rows={Object.keys(mode).map((key) => ({
+                                header: `${key.charAt(0).toUpperCase()}${key.slice(1, key.length)}`,
+                                cells: [radioButtons(key, mode[key as keyof ModeType])],
+                            }))}
+                        />
+                    </>
+                ) : null}
+            </div>
+        </TwoThirdsLayout>
+    );
+
+    function radioButtons(name: string, inputValue: string) {
+        return (
+            <div className="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+                <div className="govuk-radios__item">
+                    <input
+                        className="govuk-radios__input"
+                        id={`${name}-tnds`}
+                        name={`${name}-group`}
+                        type="radio"
+                        value="tnds"
+                        checked={inputValue === "tnds"}
+                        onChange={async () => {
+                            await updateOrg(name, Modes.tnds);
+                        }}
+                    />
+                    <label key={`${name}-tnds`} htmlFor={`${name}-tnds`} className="govuk-label govuk-radios__label">
+                        TNDS
+                    </label>
+                </div>
+                <div className="govuk-radios__item">
+                    <input
+                        className="govuk-radios__input"
+                        id={`${name}-bods`}
+                        name={`${name}-group`}
+                        type="radio"
+                        value="bods"
+                        checked={inputValue === "bods"}
+                        onChange={async () => {
+                            await updateOrg(name, Modes.bods);
+                        }}
+                    />
+                    <label key={`${name}-bods`} htmlFor={`${name}-bods`} className="govuk-label govuk-radios__label">
+                        BODS
+                    </label>
+                </div>
+            </div>
+        );
+    }
+};
 
 export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: AccountSettingsProps }> => {
     if (!ctx.req) {
@@ -52,7 +133,6 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     }
 
     const sessionWithOrg = await getSessionWithOrgDetail(ctx.req);
-
     if (!sessionWithOrg) {
         throw new Error("No session found");
     }

--- a/site/pages/account-settings.page.tsx
+++ b/site/pages/account-settings.page.tsx
@@ -1,7 +1,7 @@
 import { Modes } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
-import { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useState } from "react";
 import ErrorSummary from "../components/ErrorSummary";
 import FormElementWrapper, { FormGroupWrapper } from "../components/form/FormElementWrapper";
 import Table from "../components/form/Table";
@@ -20,7 +20,7 @@ interface AccountSettingsProps {
 }
 
 const AccountSettings = ({ sessionWithOrg, csrfToken }: AccountSettingsProps): ReactElement => {
-    const [mode, setMode] = useState<ModeType>(sessionWithOrg.mode as ModeType);
+    const [mode, setMode] = useState<ModeType>(sessionWithOrg.mode);
     const [errors, setErrors] = useState<ErrorInfo[]>([]);
 
     const updateOrg = async (key: string, value: Modes) => {

--- a/site/pages/account-settings.page.tsx
+++ b/site/pages/account-settings.page.tsx
@@ -98,7 +98,10 @@ const AccountSettings = ({ sessionWithOrg, csrfToken }: AccountSettingsProps): R
                             <FormElementWrapper errors={errors} errorId={"modes"} errorClass="govuk-radios--error">
                                 <Table
                                     rows={Object.keys(mode).map((key) => ({
-                                        header: `${key.charAt(0).toUpperCase()}${key.slice(1, key.length)}`,
+                                        header:
+                                            key === "ferryService"
+                                                ? "Ferry"
+                                                : `${key.charAt(0).toUpperCase()}${key.slice(1, key.length)}`,
                                         cells: [radioButtons(key, mode[key as keyof ModeType])],
                                     }))}
                                 />

--- a/site/pages/account-settings.test.tsx
+++ b/site/pages/account-settings.test.tsx
@@ -1,6 +1,7 @@
 import renderer from "react-test-renderer";
 import { describe, it, expect } from "vitest";
 import AccountSettings from "./account-settings.page";
+import { defaultModes } from "../schemas/organisation.schema";
 
 describe("accountSettings", () => {
     it("should render correctly", () => {
@@ -18,6 +19,7 @@ describe("accountSettings", () => {
                         isOrgStaff: true,
                         isSystemAdmin: true,
                         name: "Test User",
+                        mode: defaultModes,
                     }}
                 />,
             )

--- a/site/pages/api/admin/update-org.api.ts
+++ b/site/pages/api/admin/update-org.api.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { upsertOrganisation } from "../../../data/dynamo";
+import { organisationSchema } from "../../../schemas/organisation.schema";
+import { getSession } from "../../../utils/apiUtils/auth";
+import logger from "../../../utils/logger";
+
+const updateOrg = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const session = getSession(req);
+
+        if (!session) {
+            throw new Error("No session found");
+        } else if (!session.isOrgAdmin) {
+            throw new Error("Invalid user accessing the page");
+        }
+
+        const orgData = organisationSchema.extend({
+            PK: z.string(),
+        });
+
+        const validatedBody = orgData.safeParse(req.body);
+        if (validatedBody.success) {
+            await upsertOrganisation(validatedBody.data.PK, validatedBody.data);
+
+            res.status(200).json({ success: true });
+            return;
+        } else {
+            throw new Error("Unable to parse data from frontend");
+        }
+    } catch (e) {
+        logger.error("There was a problem while updating org data source");
+        res.status(500).json({ success: false });
+        return;
+    }
+};
+
+export default updateOrg;

--- a/site/pages/api/admin/update-org.test.ts
+++ b/site/pages/api/admin/update-org.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import updateOrg from "./update-org.api";
+import * as dynamo from "../../../data/dynamo";
+import { defaultModes } from "../../../schemas/organisation.schema";
+import { getMockRequestAndResponse, mockSession } from "../../../testData/mockData";
+import * as session from "../../../utils/apiUtils/auth";
+
+const defaultInput = {
+    PK: randomUUID(),
+    name: "Nexus",
+    adminAreaCodes: ["A", "B", "C"],
+    mode: defaultModes,
+};
+
+describe("update-org", () => {
+    const writeHeadMock = vi.fn();
+
+    vi.mock("../../../data/dynamo", () => ({
+        upsertOrganisation: vi.fn(),
+    }));
+
+    const upsertOrganisationSpy = vi.spyOn(dynamo, "upsertOrganisation");
+    const getSessionSpy = vi.spyOn(session, "getSession");
+
+    beforeEach(() => {
+        getSessionSpy.mockImplementation(() => ({ ...mockSession, isOrgAdmin: true, isSystemAdmin: false }));
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should be successful for valid input", async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: defaultInput,
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await updateOrg(req, res);
+        expect(upsertOrganisationSpy).toBeCalled();
+    });
+
+    it("should be return error when Primary key is not passed", async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: { ...defaultInput, PK: "" },
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await updateOrg(req, res);
+        expect(upsertOrganisationSpy).not.toBeCalled();
+    });
+
+    it("should be return error when invalid inputs are passed", async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: {},
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await updateOrg(req, res);
+        expect(upsertOrganisationSpy).not.toBeCalled();
+    });
+});

--- a/site/pages/change-password.test.tsx
+++ b/site/pages/change-password.test.tsx
@@ -1,6 +1,7 @@
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import ChangePassword, { ChangePasswordPageProps } from "./change-password.page";
+import { defaultModes } from "../schemas/organisation.schema";
 
 const blankInputs: ChangePasswordPageProps = {
     errors: [],
@@ -25,6 +26,7 @@ const withInputsAndNoErrors: ChangePasswordPageProps = {
         isOrgStaff: true,
         isSystemAdmin: true,
         name: "Test User",
+        mode: defaultModes,
     },
 };
 

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -357,7 +357,11 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                             initialErrors={pageState.errors}
                             placeholder="Select services"
                             getOptionLabel={getServiceLabel}
-                            options={dataSource === Modes.bods ? props.initialBodsServices : props.initialTndsServices}
+                            options={
+                                dataSource === Modes.bods
+                                    ? props.initialBodsServices ?? []
+                                    : props.initialTndsServices ?? []
+                            }
                             handleChange={handleServiceChange}
                             tableData={pageState?.inputs?.services}
                             getRows={getServiceRows}

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -413,7 +413,11 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                             state={pageState}
                             searchedRoutes={searched}
                             showSelectAllButton
-                            services={dataSource === Modes.bods ? props.initialBodsServices : props.initialTndsServices}
+                            services={
+                                dataSource === Modes.bods
+                                    ? props.initialBodsServices ?? []
+                                    : props.initialTndsServices ?? []
+                            }
                         />
 
                         <TextInput<ServicesConsequence>
@@ -599,8 +603,8 @@ export const getServerSideProps = async (
     return {
         props: {
             ...pageState,
-            initialBodsServices: bodsServices,
-            initialTndsServices: tndsServices,
+            initialBodsServices: bodsServices ?? [],
+            initialTndsServices: tndsServices ?? [],
             initialStops: stops,
             consequenceIndex: index,
             sessionWithOrg: session,

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -1,3 +1,4 @@
+import { Modes } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -36,10 +37,11 @@ import {
     servicesConsequenceSchema,
     Routes,
 } from "../../../schemas/consequence.schema";
+import { ModeType } from "../../../schemas/organisation.schema";
 import { flattenZodErrors, getServiceLabel, isServicesConsequence, sortServices } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";
-import { getStateUpdater, getStopLabel, getStopValue, sortStops } from "../../../utils/formUtils";
+import { filterServices, getStateUpdater, getStopLabel, getStopValue, sortStops } from "../../../utils/formUtils";
 
 const title = "Create Consequence Services";
 const description = "Create Consequence Services page for the Create Transport Disruptions Service";
@@ -80,6 +82,7 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
     const [servicesSearchInput, setServicesSearchInput] = useState<string>("");
     const [stopsSearchInput, setStopsSearchInput] = useState<string>("");
     const [searched, setSearchedOptions] = useState<Partial<(Routes & { serviceId: number })[]>>([]);
+    const [dataSource, setDataSource] = useState<Modes>(Modes.bods);
 
     useEffect(() => {
         const loadOptions = async () => {
@@ -241,6 +244,22 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
         }
     }, [pageState?.inputs?.services]);
 
+    useEffect(() => {
+        const source = props.sessionWithOrg?.mode[pageState?.inputs?.vehicleMode as keyof ModeType];
+        if (source && dataSource !== source) {
+            setDataSource(source);
+            setPageState({
+                ...pageState,
+                inputs: {
+                    ...pageState.inputs,
+                    services: [],
+                    stops: [],
+                },
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pageState?.inputs?.vehicleMode]);
+
     const findStopsNotToRemove = (stop: Stop, removedServiceId: number, services: Service[]) => {
         const selectedServiceIds = services.map((s) => s.id);
 
@@ -338,7 +357,7 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                             initialErrors={pageState.errors}
                             placeholder="Select services"
                             getOptionLabel={getServiceLabel}
-                            options={props.initialServices}
+                            options={dataSource === Modes.bods ? props.initialBodsServices : props.initialTndsServices}
                             handleChange={handleServiceChange}
                             tableData={pageState?.inputs?.services}
                             getRows={getServiceRows}
@@ -390,7 +409,7 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                             state={pageState}
                             searchedRoutes={searched}
                             showSelectAllButton
-                            services={props.initialServices}
+                            services={dataSource === Modes.bods ? props.initialBodsServices : props.initialTndsServices}
                         />
 
                         <TextInput<ServicesConsequence>
@@ -542,27 +561,27 @@ export const getServerSideProps = async (
         consequence && isServicesConsequence(consequence) ? consequence : undefined,
     );
 
-    let services: Service[] = [];
+    const isTndsRequired = Object.values(session.mode).find((value) => value === Modes.tnds.toString());
+    const isBodsRequired = Object.values(session.mode).find((value) => value === Modes.bods.toString());
 
-    const servicesData = await fetchServices({ adminAreaCodes: session.adminAreaCodes ?? ["undefined"] });
+    const [bodsServicesData, tndsServicesData] = await Promise.all([
+        isBodsRequired
+            ? fetchServices({
+                  adminAreaCodes: session.adminAreaCodes ?? ["undefined"],
+              })
+            : undefined,
+        isTndsRequired
+            ? fetchServices({
+                  adminAreaCodes: session.adminAreaCodes ?? ["undefined"],
+                  dataSource: Modes.tnds,
+              })
+            : undefined,
+    ]);
 
-    if (servicesData.length > 0) {
-        services = sortServices(servicesData);
-
-        const setOfServices = new Set();
-
-        const filteredServices: Service[] = services.filter((item) => {
-            const serviceDisplay = item.lineName + item.origin + item.destination + item.operatorShortName;
-            if (!setOfServices.has(serviceDisplay)) {
-                setOfServices.add(serviceDisplay);
-                return true;
-            } else {
-                return false;
-            }
-        });
-
-        services = filteredServices;
-    }
+    const [bodsServices, tndsServices] = await Promise.all([
+        filterServices(bodsServicesData),
+        filterServices(tndsServicesData),
+    ]);
 
     let stops: Stop[] = [];
 
@@ -576,7 +595,8 @@ export const getServerSideProps = async (
     return {
         props: {
             ...pageState,
-            initialServices: services,
+            initialBodsServices: bodsServices,
+            initialTndsServices: tndsServices,
             initialStops: stops,
             consequenceIndex: index,
             sessionWithOrg: session,

--- a/site/pages/create-consequence-services/create-consequence-services.test.tsx
+++ b/site/pages/create-consequence-services/create-consequence-services.test.tsx
@@ -2,6 +2,7 @@ import { Severity } from "@create-disruptions-data/shared-ts/enums";
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import CreateConsequenceServices, { CreateConsequenceServicesProps } from "./[disruptionId]/[consequenceIndex].page";
+import { defaultModes } from "../../schemas/organisation.schema";
 
 const blankInputs: CreateConsequenceServicesProps = {
     errors: [],
@@ -17,6 +18,7 @@ const blankInputs: CreateConsequenceServicesProps = {
         isOrgStaff: true,
         isSystemAdmin: true,
         name: "Test User",
+        mode: defaultModes,
     },
 };
 
@@ -34,6 +36,7 @@ const withInputs: CreateConsequenceServicesProps = {
         isOrgStaff: true,
         isSystemAdmin: true,
         name: "Test User",
+        mode: defaultModes,
     },
     inputs: {
         stops: [
@@ -91,6 +94,7 @@ const withInputsAndErrors: CreateConsequenceServicesProps = {
         isOrgStaff: true,
         isSystemAdmin: true,
         name: "Test User",
+        mode: defaultModes,
     },
     errors: [
         { errorMessage: "Enter a description for this disruption", id: "description" },

--- a/site/pages/create-consequence-stops/create-consequence-stops.test.tsx
+++ b/site/pages/create-consequence-stops/create-consequence-stops.test.tsx
@@ -2,6 +2,7 @@ import { Severity } from "@create-disruptions-data/shared-ts/enums";
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import CreateConsequenceStops, { CreateConsequenceStopsProps } from "./[disruptionId]/[consequenceIndex].page";
+import { defaultModes } from "../../schemas/organisation.schema";
 
 const blankInputs: CreateConsequenceStopsProps = {
     errors: [],
@@ -44,6 +45,7 @@ const withInputs: CreateConsequenceStopsProps = {
         isOrgStaff: true,
         isSystemAdmin: true,
         name: "Test User",
+        mode: defaultModes,
     },
 };
 
@@ -83,6 +85,7 @@ const withInputsAndErrors: CreateConsequenceStopsProps = {
         isOrgStaff: true,
         isSystemAdmin: true,
         name: "Test User",
+        mode: defaultModes,
     },
 };
 

--- a/site/pages/dashboard.test.tsx
+++ b/site/pages/dashboard.test.tsx
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import Dashboard, { DashboardDisruption, getServerSideProps } from "./dashboard.page";
 import { CD_DATE_FORMAT } from "../constants";
 import * as dynamo from "../data/dynamo";
+import { defaultModes } from "../schemas/organisation.schema";
 import { SessionWithOrgDetail } from "../schemas/session.schema";
 import { disruptionArray, disruptionWithConsequencesAndSocialMediaPosts, getMockContext } from "../testData/mockData";
 import * as session from "../utils/apiUtils/auth";
@@ -38,6 +39,7 @@ const defaultSession: SessionWithOrgDetail = {
     name: "Test User",
     orgName: "Nexus",
     adminAreaCodes: ["A", "B", "C"],
+    mode: defaultModes,
 };
 
 const disruptions: DashboardDisruption[] = [

--- a/site/pages/sysadmin/manage-organisations.test.tsx
+++ b/site/pages/sysadmin/manage-organisations.test.tsx
@@ -36,6 +36,7 @@ const defaultSession: SessionWithOrgDetail = {
     name: "Test User",
     orgName: "Nexus",
     adminAreaCodes: ["A", "B", "C"],
+    mode: defaultModes,
 };
 
 const getSessionWithOrgDetailSpy = vi.spyOn(session, "getSessionWithOrgDetail");

--- a/site/pages/sysadmin/manage-organisations.test.tsx
+++ b/site/pages/sysadmin/manage-organisations.test.tsx
@@ -1,6 +1,7 @@
 import renderer from "react-test-renderer";
 import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import ManageOrganisations, { ManageOrganisationsProps } from "./manage-organisations.page";
+import { defaultModes } from "../../schemas/organisation.schema";
 import { SessionWithOrgDetail } from "../../schemas/session.schema";
 import * as session from "../../utils/apiUtils/auth";
 

--- a/site/pages/sysadmin/users.test.tsx
+++ b/site/pages/sysadmin/users.test.tsx
@@ -2,9 +2,9 @@ import { UserGroups } from "@create-disruptions-data/shared-ts/enums";
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import AdminUsers, { AdminUserProps } from "./users.page";
+import { defaultModes } from "../../schemas/organisation.schema";
 import { SessionWithOrgDetail } from "../../schemas/session.schema";
 import * as session from "../../utils/apiUtils/auth";
-import { defaultModes } from "../../schemas/organisation.schema";
 
 const blankInputs: AdminUserProps = {
     inputs: {},

--- a/site/pages/sysadmin/users.test.tsx
+++ b/site/pages/sysadmin/users.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import AdminUsers, { AdminUserProps } from "./users.page";
 import { SessionWithOrgDetail } from "../../schemas/session.schema";
 import * as session from "../../utils/apiUtils/auth";
+import { defaultModes } from "../../schemas/organisation.schema";
 
 const blankInputs: AdminUserProps = {
     inputs: {},
@@ -50,6 +51,7 @@ const defaultSession: SessionWithOrgDetail = {
     name: "Test User",
     orgName: "Nexus",
     adminAreaCodes: ["A", "B", "C"],
+    mode: defaultModes,
 };
 
 const getSessionWithOrgDetailSpy = vi.spyOn(session, "getSessionWithOrgDetail");

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -40,7 +40,6 @@ import {
     getServiceLabel,
     mapValidityPeriods,
     getDisplayByValue,
-    sortServices,
     SortedDisruption,
     getSortedDisruptionFinalEndDate,
 } from "../utils";

--- a/site/schemas/consequence.schema.ts
+++ b/site/schemas/consequence.schema.ts
@@ -73,6 +73,7 @@ export const serviceSchema = z.object({
     destination: z.string(),
     origin: z.string(),
     nocCode: z.string(),
+    dataSource: z.string().optional(),
 });
 
 export const serviceByStopSchema = serviceSchema.and(

--- a/site/schemas/organisation.schema.ts
+++ b/site/schemas/organisation.schema.ts
@@ -17,7 +17,7 @@ export const organisationSchema = z.object({
     name: z.string(setZodDefaultError("Enter an organisation name")).min(3),
     adminAreaCodes: z.array(z.string()).min(1, { message: "Atleast 1 area code is required" }),
     PK: z.string().optional(),
-    mode: modeSchema.optional().default(defaultModes),
+    mode: modeSchema.default(defaultModes).optional(),
 });
 
 export type Organisation = z.infer<typeof organisationSchema>;

--- a/site/schemas/organisation.schema.ts
+++ b/site/schemas/organisation.schema.ts
@@ -5,13 +5,13 @@ import { setZodDefaultError } from "../utils";
 export const modeSchema = z.object({
     bus: z.nativeEnum(Modes),
     tram: z.nativeEnum(Modes),
-    ferry: z.nativeEnum(Modes),
+    ferryService: z.nativeEnum(Modes),
     rail: z.nativeEnum(Modes),
 });
 
 export type ModeType = z.infer<typeof modeSchema>;
 
-export const defaultModes: ModeType = { bus: Modes.bods, tram: Modes.bods, ferry: Modes.bods, rail: Modes.bods };
+export const defaultModes: ModeType = { bus: Modes.bods, tram: Modes.bods, ferryService: Modes.bods, rail: Modes.bods };
 
 export const organisationSchema = z.object({
     name: z.string(setZodDefaultError("Enter an organisation name")).min(3),

--- a/site/schemas/organisation.schema.ts
+++ b/site/schemas/organisation.schema.ts
@@ -11,7 +11,7 @@ export const modeSchema = z.object({
 
 export type ModeType = z.infer<typeof modeSchema>;
 
-const defaultModes: ModeType = { bus: Modes.bods, tram: Modes.bods, ferry: Modes.bods, rail: Modes.bods };
+export const defaultModes: ModeType = { bus: Modes.bods, tram: Modes.bods, ferry: Modes.bods, rail: Modes.bods };
 
 export const organisationSchema = z.object({
     name: z.string(setZodDefaultError("Enter an organisation name")).min(3),

--- a/site/schemas/organisation.schema.ts
+++ b/site/schemas/organisation.schema.ts
@@ -1,8 +1,21 @@
+import { Modes } from "@create-disruptions-data/shared-ts/enums";
 import { z } from "zod";
+
+export const modeSchema = z.object({
+    bus: z.nativeEnum(Modes),
+    tram: z.nativeEnum(Modes),
+    ferry: z.nativeEnum(Modes),
+    rail: z.nativeEnum(Modes),
+});
+
+export type ModeType = z.infer<typeof modeSchema>;
+
+const defaultModes: ModeType = { bus: Modes.bods, tram: Modes.bods, ferry: Modes.bods, rail: Modes.bods };
 
 export const organisationSchema = z.object({
     name: z.string(),
     adminAreaCodes: z.array(z.string()),
+    mode: modeSchema.optional().default(defaultModes),
 });
 
 export type Organisation = z.infer<typeof organisationSchema>;

--- a/site/schemas/session.schema.ts
+++ b/site/schemas/session.schema.ts
@@ -36,6 +36,7 @@ export const sessionSchemaWithOrgDetail = sessionSchema.transform(async (item) =
         ...item,
         orgName: orgDetail?.name ?? "",
         adminAreaCodes: orgDetail?.adminAreaCodes ?? [],
+        mode: orgDetail?.mode,
     };
 });
 

--- a/site/schemas/session.schema.ts
+++ b/site/schemas/session.schema.ts
@@ -1,5 +1,6 @@
 import { UserGroups } from "@create-disruptions-data/shared-ts/enums";
 import { z } from "zod";
+import { defaultModes } from "./organisation.schema";
 import { getOrganisationInfoById } from "../data/dynamo";
 
 export const sessionSchema = z
@@ -36,7 +37,7 @@ export const sessionSchemaWithOrgDetail = sessionSchema.transform(async (item) =
         ...item,
         orgName: orgDetail?.name ?? "",
         adminAreaCodes: orgDetail?.adminAreaCodes ?? [],
-        mode: orgDetail?.mode,
+        mode: orgDetail?.mode ?? defaultModes,
     };
 });
 

--- a/site/testData/mockData.ts
+++ b/site/testData/mockData.ts
@@ -21,7 +21,6 @@ import { Consequence, Operator, Service } from "../schemas/consequence.schema";
 import { DisruptionInfo } from "../schemas/create-disruption.schema";
 import { Disruption, ExportDisruptions } from "../schemas/disruption.schema";
 import { Session } from "../schemas/session.schema";
-import { type } from "os";
 
 export const DEFAULT_ORG_ID = "35bae327-4af0-4bbf-8bfa-2c085f214483";
 export const DEFAULT_DISRUPTION_ID = "8befe1e9-e317-45af-825a-e0254fabf49d";

--- a/site/testData/mockData.ts
+++ b/site/testData/mockData.ts
@@ -21,11 +21,16 @@ import { Consequence, Operator, Service } from "../schemas/consequence.schema";
 import { DisruptionInfo } from "../schemas/create-disruption.schema";
 import { Disruption, ExportDisruptions } from "../schemas/disruption.schema";
 import { Session } from "../schemas/session.schema";
+import { type } from "os";
 
 export const DEFAULT_ORG_ID = "35bae327-4af0-4bbf-8bfa-2c085f214483";
 export const DEFAULT_DISRUPTION_ID = "8befe1e9-e317-45af-825a-e0254fabf49d";
 
 export const DEFAULT_IMAGE_BUCKET_NAME = "cdd-image-bucket";
+
+type RecordType = {
+    [name: string]: string | string[] | undefined;
+};
 
 export interface GetMockContextInput {
     session?: Record<string, string> | null;
@@ -127,7 +132,7 @@ export const getMockContext = ({
 
 export interface GetMockRequestAndResponse {
     cookieValues?: Record<string, string>;
-    body?: Record<string, string | string[]> | null;
+    body?: Record<string, string | string[] | RecordType> | null;
     uuid?: string | null;
     mockWriteHeadFn?: Mock | null;
     mockEndFn?: Mock | null;

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -87,27 +87,25 @@ export const getStopType = (stopType: string | undefined) => {
 };
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export const filterServices = async (servicesData: Service[] | undefined): Promise<Service[] | null> => {
-    return new Promise((resolve) => {
-        let services: Service[] | null = null;
-        if (servicesData && servicesData.length > 0) {
-            services = sortServices(servicesData);
+export const filterServices = async (servicesData?: Service[]) => {
+    let services: Service[] = [];
+    if (servicesData && servicesData.length > 0) {
+        services = sortServices(servicesData);
 
-            const setOfServices = new Set();
+        const setOfServices = new Set();
 
-            const filteredServices: Service[] = services.filter((item) => {
-                const serviceDisplay = item.lineName + item.origin + item.destination + item.operatorShortName;
-                if (!setOfServices.has(serviceDisplay)) {
-                    setOfServices.add(serviceDisplay);
-                    return true;
-                } else {
-                    return false;
-                }
-            });
+        const filteredServices: Service[] = services.filter((item) => {
+            const serviceDisplay = item.lineName + item.origin + item.destination + item.operatorShortName;
+            if (!setOfServices.has(serviceDisplay)) {
+                setOfServices.add(serviceDisplay);
+                return true;
+            } else {
+                return false;
+            }
+        });
 
-            services = filteredServices;
-        }
+        services = filteredServices;
+    }
 
-        resolve(services);
-    });
+    return services;
 };

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -1,7 +1,8 @@
 import { Dispatch, SetStateAction } from "react";
 import { z } from "zod";
 import { ErrorInfo, PageState } from "../interfaces";
-import { Stop } from "../schemas/consequence.schema";
+import { Service, Stop } from "../schemas/consequence.schema";
+import { sortServices } from ".";
 
 export const handleBlur = <T>(
     input: string,
@@ -83,4 +84,30 @@ export const getStopType = (stopType: string | undefined) => {
     } else {
         return "Stop";
     }
+};
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const filterServices = async (servicesData: Service[] | undefined): Promise<Service[] | null> => {
+    return new Promise((resolve) => {
+        let services: Service[] | null = null;
+        if (servicesData && servicesData.length > 0) {
+            services = sortServices(servicesData);
+
+            const setOfServices = new Set();
+
+            const filteredServices: Service[] = services.filter((item) => {
+                const serviceDisplay = item.lineName + item.origin + item.destination + item.operatorShortName;
+                if (!setOfServices.has(serviceDisplay)) {
+                    setOfServices.add(serviceDisplay);
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+
+            services = filteredServices;
+        }
+
+        resolve(services);
+    });
 };


### PR DESCRIPTION
Testing instructions

- Login as org admin user and then access the Account Settings page from top right corner. The radio buttons should be displayed only to org admins
- After the source data is clicked - navigate to consequence services page and observe that the services data changes based on the source for mode of transport
- The services dropdown in view  all disruptions page should display both tnds and bods data