### PR TITLE
Add OperatorName field to Siri SX for consequences of type operator

### DIFF
--- a/site/components/OperatorSearch.test.tsx
+++ b/site/components/OperatorSearch.test.tsx
@@ -1,17 +1,18 @@
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi } from "vitest";
 import OperatorSearch from "./OperatorSearch";
+import { OperatorConsequence } from "../schemas/consequence.schema";
 import { mockOperators } from "../testData/mockData";
 
 describe("OperatorSearch", () => {
     it("should render correctly with no errors", () => {
         const tree = renderer
             .create(
-                <OperatorSearch
+                <OperatorSearch<OperatorConsequence>
                     display="Operators impacted"
                     displaySize="l"
                     operators={mockOperators}
-                    selectedOperatorNocs={[]}
+                    selectedOperators={[]}
                     stateUpdater={vi.fn()}
                     initialErrors={[]}
                     inputName="consequenceOperators"
@@ -24,11 +25,11 @@ describe("OperatorSearch", () => {
     it("should render correctly with errors", () => {
         const tree = renderer
             .create(
-                <OperatorSearch
+                <OperatorSearch<OperatorConsequence>
                     display="Operators impacted"
                     displaySize="l"
                     operators={mockOperators}
-                    selectedOperatorNocs={[]}
+                    selectedOperators={[]}
                     stateUpdater={vi.fn()}
                     initialErrors={[{ errorMessage: "Select one or more operators", id: "consequence-operators" }]}
                     inputName="consequenceOperators"

--- a/site/components/OperatorSearch.tsx
+++ b/site/components/OperatorSearch.tsx
@@ -40,7 +40,6 @@ const OperatorSearch = <T extends object>({
 }: OperatorSearchProps<T>): ReactElement => {
     const [searchText, setSearchText] = useState("");
 
-    console.log("data------", selectedOperators);
     useEffect(() => {
         if (reset) {
             handleChange<T>([], inputName, stateUpdater);
@@ -95,7 +94,7 @@ const OperatorSearch = <T extends object>({
                                     operatorNoc: operator.nocCode,
                                     operatorPublicName: operator.operatorPublicName,
                                 });
-                                handleChange([selectedOperators], inputName, stateUpdater);
+                                handleChange(selectedOperators, inputName, stateUpdater);
                             }
                         }}
                         id="operator-search"

--- a/site/components/OperatorSearch.tsx
+++ b/site/components/OperatorSearch.tsx
@@ -3,12 +3,12 @@ import { ReactElement, useEffect, useState } from "react";
 import Select, { ControlProps, GroupBase, OptionProps } from "react-select";
 import FormElementWrapper, { FormGroupWrapper } from "./form/FormElementWrapper";
 import { ErrorInfo } from "../interfaces";
-import { Operator } from "../schemas/consequence.schema";
+import { ConsequenceOperators, Operator } from "../schemas/consequence.schema";
 
 interface OperatorSearchProps<T> {
     operators: Operator[];
-    stateUpdater: (change: string[], field: keyof T) => void;
-    selectedOperatorNocs: string[];
+    stateUpdater: (change: ConsequenceOperators[], field: keyof T) => void;
+    selectedOperators: ConsequenceOperators[];
     reset?: boolean;
     display: string;
     displaySize?: "s" | "m" | "l" | "xl";
@@ -21,9 +21,9 @@ export const sortOperatorByName = (operators: Operator[]): Operator[] => {
 };
 
 const handleChange = <T,>(
-    input: string[],
+    input: ConsequenceOperators[],
     inputName: keyof T,
-    stateUpdater: (change: string[], field: keyof T) => void,
+    stateUpdater: (change: ConsequenceOperators[], field: keyof T) => void,
 ) => {
     stateUpdater(input, inputName);
 };
@@ -33,7 +33,7 @@ const OperatorSearch = <T extends object>({
     displaySize = "m",
     operators,
     stateUpdater,
-    selectedOperatorNocs,
+    selectedOperators,
     reset = false,
     initialErrors = [],
     inputName,
@@ -89,8 +89,12 @@ const OperatorSearch = <T extends object>({
                         }}
                         inputValue={searchText}
                         onChange={(operator) => {
-                            if (!!operator && !selectedOperatorNocs.find((noc) => noc === operator.nocCode)) {
-                                handleChange([...selectedOperatorNocs, operator.nocCode], inputName, stateUpdater);
+                            if (!!operator && !selectedOperators.find((noc) => noc.operatorNoc === operator.nocCode)) {
+                                selectedOperators.push({
+                                    operatorNoc: operator.nocCode,
+                                    operatorPublicName: operator.operatorPublicName,
+                                });
+                                handleChange(selectedOperators, inputName, stateUpdater);
                             }
                         }}
                         id="operator-search"

--- a/site/components/OperatorSearch.tsx
+++ b/site/components/OperatorSearch.tsx
@@ -7,7 +7,7 @@ import { ConsequenceOperators, Operator } from "../schemas/consequence.schema";
 
 interface OperatorSearchProps<T> {
     operators: Operator[];
-    stateUpdater: (change: string[] | ConsequenceOperators[], field: keyof T) => void;
+    stateUpdater: (change: ConsequenceOperators[], field: keyof T) => void;
     selectedOperators: ConsequenceOperators[];
     reset?: boolean;
     display: string;
@@ -40,6 +40,7 @@ const OperatorSearch = <T extends object>({
 }: OperatorSearchProps<T>): ReactElement => {
     const [searchText, setSearchText] = useState("");
 
+    console.log("data------", selectedOperators);
     useEffect(() => {
         if (reset) {
             handleChange<T>([], inputName, stateUpdater);
@@ -94,7 +95,7 @@ const OperatorSearch = <T extends object>({
                                     operatorNoc: operator.nocCode,
                                     operatorPublicName: operator.operatorPublicName,
                                 });
-                                handleChange(selectedOperators, inputName, stateUpdater);
+                                handleChange([selectedOperators], inputName, stateUpdater);
                             }
                         }}
                         id="operator-search"

--- a/site/components/OperatorSearch.tsx
+++ b/site/components/OperatorSearch.tsx
@@ -7,7 +7,7 @@ import { ConsequenceOperators, Operator } from "../schemas/consequence.schema";
 
 interface OperatorSearchProps<T> {
     operators: Operator[];
-    stateUpdater: (change: ConsequenceOperators[], field: keyof T) => void;
+    stateUpdater: (change: string[] | ConsequenceOperators[], field: keyof T) => void;
     selectedOperators: ConsequenceOperators[];
     reset?: boolean;
     display: string;

--- a/site/components/ReviewConsequenceTable.tsx
+++ b/site/components/ReviewConsequenceTable.tsx
@@ -136,7 +136,9 @@ const getRows = (consequence: Consequence, disruption: Disruption, isDisruptionD
         rows.push({
             header: "Operators affected",
             cells: [
-                consequence.consequenceOperators ? consequence.consequenceOperators.join(", ") : "N/A",
+                consequence.consequenceOperators
+                    ? consequence.consequenceOperators.map((op) => op.operatorNoc).join(", ")
+                    : "N/A",
                 createChangeLink(
                     "operators-affected",
                     getConsequenceUrl(consequence.consequenceType),

--- a/site/pages/api/__snapshots__/delete-disruption.test.ts.snap
+++ b/site/pages/api/__snapshots__/delete-disruption.test.ts.snap
@@ -15,7 +15,10 @@ exports[`deleteDisruption > should write the correct disruptions data to dynamoD
     {
       "consequenceIndex": 0,
       "consequenceOperators": [
-        "FSYO",
+        {
+          "operatorNoc": "FSYO",
+          "operatorPublicName": "Operator Name",
+        },
       ],
       "consequenceType": "operatorWide",
       "description": "Some consequence description",

--- a/site/pages/api/__snapshots__/publish-edit.test.ts.snap
+++ b/site/pages/api/__snapshots__/publish-edit.test.ts.snap
@@ -37,6 +37,7 @@ exports[`publishEdit > should write the correct disruptions data to dynamoDB 1`]
             "Operators": {
               "AffectedOperator": [
                 {
+                  "OperatorName": "Operator Name",
                   "OperatorRef": "FSYO",
                 },
               ],
@@ -93,7 +94,10 @@ exports[`publishEdit > should write the correct disruptions data to dynamoDB 1`]
       {
         "consequenceIndex": 0,
         "consequenceOperators": [
-          "FSYO",
+          {
+            "operatorNoc": "FSYO",
+            "operatorPublicName": "Operator Name",
+          },
         ],
         "consequenceType": "operatorWide",
         "description": "Some consequence description",

--- a/site/pages/api/__snapshots__/publish.test.ts.snap
+++ b/site/pages/api/__snapshots__/publish.test.ts.snap
@@ -37,6 +37,7 @@ exports[`publish > should write the correct disruptions data to dynamoDB 1`] = `
             "Operators": {
               "AffectedOperator": [
                 {
+                  "OperatorName": "Operator Name",
                   "OperatorRef": "FSYO",
                 },
               ],
@@ -93,7 +94,10 @@ exports[`publish > should write the correct disruptions data to dynamoDB 1`] = `
       {
         "consequenceIndex": 0,
         "consequenceOperators": [
-          "FSYO",
+          {
+            "operatorNoc": "FSYO",
+            "operatorPublicName": "Operator Name",
+          },
         ],
         "consequenceType": "operatorWide",
         "description": "Some consequence description",

--- a/site/pages/api/__snapshots__/reject.test.ts.snap
+++ b/site/pages/api/__snapshots__/reject.test.ts.snap
@@ -37,6 +37,7 @@ exports[`reject > should write the correct disruptions data to dynamoDB 1`] = `
             "Operators": {
               "AffectedOperator": [
                 {
+                  "OperatorName": "Operator Name",
                   "OperatorRef": "FSYO",
                 },
               ],
@@ -93,7 +94,10 @@ exports[`reject > should write the correct disruptions data to dynamoDB 1`] = `
       {
         "consequenceIndex": 0,
         "consequenceOperators": [
-          "FSYO",
+          {
+            "operatorNoc": "FSYO",
+            "operatorPublicName": "Operator Name",
+          },
         ],
         "consequenceType": "operatorWide",
         "description": "Some consequence description",
@@ -169,6 +173,7 @@ exports[`reject > should write the correct disruptions data to dynamoDB 3`] = `
             "Operators": {
               "AffectedOperator": [
                 {
+                  "OperatorName": "Operator Name",
                   "OperatorRef": "FSYO",
                 },
               ],
@@ -225,7 +230,10 @@ exports[`reject > should write the correct disruptions data to dynamoDB 3`] = `
       {
         "consequenceIndex": 0,
         "consequenceOperators": [
-          "FSYO",
+          {
+            "operatorNoc": "FSYO",
+            "operatorPublicName": "Operator Name",
+          },
         ],
         "consequenceType": "operatorWide",
         "description": "Some consequence description",

--- a/site/pages/api/create-consequence-operator.api.ts
+++ b/site/pages/api/create-consequence-operator.api.ts
@@ -27,7 +27,7 @@ interface OperatorConsequenceRequest extends NextApiRequest {
 const createConsequenceOperator = async (req: OperatorConsequenceRequest, res: NextApiResponse): Promise<void> => {
     try {
         const queryParam = getReturnPage(req);
-        const consequenceOperatorsData = req.body.consequenceOperators;
+        // const consequenceOperatorsData = req.body.consequenceOperators;
         const session = getSession(req);
 
         const { draft } = req.query;
@@ -36,25 +36,24 @@ const createConsequenceOperator = async (req: OperatorConsequenceRequest, res: N
             throw new Error("No session found");
         }
 
-        const consequenceOperators: string[] =
-            !!consequenceOperatorsData && consequenceOperatorsData.includes(",")
-                ? consequenceOperatorsData.split(",")
-                : !!consequenceOperatorsData
-                ? [consequenceOperatorsData]
-                : [];
+        // const consequenceOperators: string[] =
+        //     !!consequenceOperatorsData && consequenceOperatorsData.includes(",")
+        //         ? consequenceOperatorsData.split(",")
+        //         : !!consequenceOperatorsData
+        //         ? [consequenceOperatorsData]
+        //         : [];
 
-        const consequence: OperatorConsequence = {
-            ...req.body,
-            consequenceOperators,
-        };
+        const consequence: OperatorConsequence = req.body as OperatorConsequence;
 
-        const validatedBody = operatorConsequenceSchema.safeParse(consequence);
+        // const validatedBody = operatorConsequenceSchema.safeParse(consequence);
+        const validatedBody = operatorConsequenceSchema.safeParse(req.body);
 
         if (!validatedBody.success) {
             if (!consequence.disruptionId || !consequence.consequenceIndex) {
                 throw new Error("No disruptionId or consequenceIndex found");
             }
 
+            console.log("errors------", flattenZodErrors(validatedBody.error));
             setCookieOnResponseObject(
                 COOKIES_CONSEQUENCE_OPERATOR_ERRORS,
                 JSON.stringify({

--- a/site/pages/api/create-consequence-operator.test.ts
+++ b/site/pages/api/create-consequence-operator.test.ts
@@ -10,10 +10,10 @@ import {
 } from "../../constants";
 import * as dynamo from "../../data/dynamo";
 import { ErrorInfo } from "../../interfaces";
+import { ConsequenceOperators } from "../../schemas/consequence.schema";
 import { DEFAULT_ORG_ID, getMockRequestAndResponse, mockSession } from "../../testData/mockData";
 import { setCookieOnResponseObject } from "../../utils/apiUtils";
 import * as session from "../../utils/apiUtils/auth";
-import { ConsequenceOperators } from "../../schemas/consequence.schema";
 
 const defaultDisruptionId = "acde070d-8c4c-4f0d-9d8a-162843c10333";
 const defaultConsequenceIndex = "0";

--- a/site/pages/api/create-consequence-operator.test.ts
+++ b/site/pages/api/create-consequence-operator.test.ts
@@ -26,7 +26,7 @@ const defaultConsequenceOperators: ConsequenceOperators[] = [
 ];
 
 const bodyData = {
-    consequenceOperators: defaultConsequenceOperators,
+    consequenceOperators: JSON.stringify(defaultConsequenceOperators),
     description:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     removeFromJourneyPlanners: "no",

--- a/site/pages/api/create-consequence-operator.test.ts
+++ b/site/pages/api/create-consequence-operator.test.ts
@@ -13,12 +13,20 @@ import { ErrorInfo } from "../../interfaces";
 import { DEFAULT_ORG_ID, getMockRequestAndResponse, mockSession } from "../../testData/mockData";
 import { setCookieOnResponseObject } from "../../utils/apiUtils";
 import * as session from "../../utils/apiUtils/auth";
+import { ConsequenceOperators } from "../../schemas/consequence.schema";
 
 const defaultDisruptionId = "acde070d-8c4c-4f0d-9d8a-162843c10333";
 const defaultConsequenceIndex = "0";
 
+const defaultConsequenceOperators: ConsequenceOperators[] = [
+    {
+        operatorNoc: "FMAN",
+        operatorPublicName: "Another operator",
+    },
+];
+
 const bodyData = {
-    consequenceOperators: "FMAN",
+    consequenceOperators: defaultConsequenceOperators,
     description:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     removeFromJourneyPlanners: "no",
@@ -71,7 +79,7 @@ describe("create-consequence-operator API", () => {
                 disruptionSeverity: "slight",
                 vehicleMode: "bus",
                 consequenceIndex: 0,
-                consequenceOperators: ["FMAN"],
+                consequenceOperators: defaultConsequenceOperators,
                 consequenceType: "operatorWide",
             },
             DEFAULT_ORG_ID,
@@ -136,7 +144,7 @@ describe("create-consequence-operator API", () => {
             JSON.stringify({
                 inputs: {
                     ...bodyData,
-                    consequenceOperators: ["FMAN"],
+                    consequenceOperators: defaultConsequenceOperators,
                     description:
                         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
                 },
@@ -167,7 +175,7 @@ describe("create-consequence-operator API", () => {
             JSON.stringify({
                 inputs: {
                     ...bodyData,
-                    consequenceOperators: ["FMAN"],
+                    consequenceOperators: defaultConsequenceOperators,
                     disruptionDelay: "7280",
                 },
                 errors,
@@ -199,7 +207,7 @@ describe("create-consequence-operator API", () => {
                 disruptionSeverity: "slight",
                 vehicleMode: "bus",
                 consequenceIndex: 0,
-                consequenceOperators: ["FMAN"],
+                consequenceOperators: defaultConsequenceOperators,
                 consequenceType: "operatorWide",
             },
             DEFAULT_ORG_ID,

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -42,7 +42,7 @@ export interface CreateConsequenceOperatorProps
 const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): ReactElement => {
     const [pageState, setConsequenceOperatorPageState] = useState<PageState<Partial<OperatorConsequence>>>(props);
 
-    const stateUpdater = getStateUpdater(setConsequenceOperatorPageState, pageState);
+    //const stateUpdater = getStateUpdater(setConsequenceOperatorPageState, pageState);
 
     const operatorStateUpdate = operatorStateUpdater(setConsequenceOperatorPageState, pageState);
 
@@ -83,7 +83,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             display="Mode of transport"
                             defaultDisplay="Select mode of transport"
                             selectValues={VEHICLE_MODES}
-                            stateUpdater={stateUpdater}
+                            stateUpdater={operatorStateUpdate}
                             value={pageState.inputs.vehicleMode}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.vehicleMode}
@@ -95,11 +95,11 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             displaySize="l"
                             operators={props.operators.filter(
                                 (op) =>
-                                    !(pageState.inputs.consequenceOperators || []).find(
+                                    !pageState.inputs.consequenceOperators?.find(
                                         (selOp) => selOp.operatorNoc === op.nocCode,
                                     ),
                             )}
-                            selectedOperators={pageState.inputs.consequenceOperators || []}
+                            selectedOperators={pageState.inputs?.consequenceOperators ?? []}
                             stateUpdater={operatorStateUpdate}
                             initialErrors={pageState.inputs.consequenceOperators?.length === 0 ? pageState.errors : []}
                             inputName="consequenceOperators"
@@ -154,7 +154,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             textArea
                             rows={3}
                             maxLength={500}
-                            stateUpdater={stateUpdater}
+                            stateUpdater={operatorStateUpdate}
                             value={pageState.inputs.description}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.description}
@@ -174,7 +174,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                                 },
                             ]}
                             inputName="removeFromJourneyPlanners"
-                            stateUpdater={stateUpdater}
+                            stateUpdater={operatorStateUpdate}
                             value={pageState.inputs.removeFromJourneyPlanners}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.removeFromJourneyPlanners}
@@ -186,7 +186,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             value={pageState.inputs.disruptionDelay}
                             disabled={false}
                             inputName="disruptionDelay"
-                            stateUpdater={stateUpdater}
+                            stateUpdater={operatorStateUpdate}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.disruptionDelay}
                             placeholderValue=""
@@ -198,7 +198,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             displaySize="l"
                             defaultDisplay="Select severity"
                             selectValues={DISRUPTION_SEVERITIES}
-                            stateUpdater={stateUpdater}
+                            stateUpdater={operatorStateUpdate}
                             value={pageState.inputs.disruptionSeverity}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.disruptionSeverity}
@@ -268,6 +268,7 @@ export const getServerSideProps = async (
         consequence && isOperatorConsequence(consequence) ? consequence : undefined,
     );
 
+    console.log("pageState-----", pageState.inputs.consequenceOperators);
     if (ctx.res) destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_OPERATOR_ERRORS, ctx.res);
 
     const operators = await fetchOperators({ adminAreaCodes: session.adminAreaCodes ?? ["undefined"] });

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -42,7 +42,7 @@ export interface CreateConsequenceOperatorProps
 const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): ReactElement => {
     const [pageState, setConsequenceOperatorPageState] = useState<PageState<Partial<OperatorConsequence>>>(props);
 
-    //const stateUpdater = getStateUpdater(setConsequenceOperatorPageState, pageState);
+    const stateUpdater = getStateUpdater(setConsequenceOperatorPageState, pageState);
 
     const operatorStateUpdate = operatorStateUpdater(setConsequenceOperatorPageState, pageState);
 
@@ -83,7 +83,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             display="Mode of transport"
                             defaultDisplay="Select mode of transport"
                             selectValues={VEHICLE_MODES}
-                            stateUpdater={operatorStateUpdate}
+                            stateUpdater={stateUpdater}
                             value={pageState.inputs.vehicleMode}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.vehicleMode}
@@ -154,7 +154,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             textArea
                             rows={3}
                             maxLength={500}
-                            stateUpdater={operatorStateUpdate}
+                            stateUpdater={stateUpdater}
                             value={pageState.inputs.description}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.description}
@@ -174,7 +174,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                                 },
                             ]}
                             inputName="removeFromJourneyPlanners"
-                            stateUpdater={operatorStateUpdate}
+                            stateUpdater={stateUpdater}
                             value={pageState.inputs.removeFromJourneyPlanners}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.removeFromJourneyPlanners}
@@ -186,7 +186,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             value={pageState.inputs.disruptionDelay}
                             disabled={false}
                             inputName="disruptionDelay"
-                            stateUpdater={operatorStateUpdate}
+                            stateUpdater={stateUpdater}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.disruptionDelay}
                             placeholderValue=""
@@ -198,7 +198,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             displaySize="l"
                             defaultDisplay="Select severity"
                             selectValues={DISRUPTION_SEVERITIES}
-                            stateUpdater={operatorStateUpdate}
+                            stateUpdater={stateUpdater}
                             value={pageState.inputs.disruptionSeverity}
                             initialErrors={pageState.errors}
                             schema={operatorConsequenceSchema.shape.disruptionSeverity}
@@ -268,7 +268,8 @@ export const getServerSideProps = async (
         consequence && isOperatorConsequence(consequence) ? consequence : undefined,
     );
 
-    console.log("pageState-----", pageState.inputs.consequenceOperators);
+    const consequenceOperators = pageState.inputs.consequenceOperators;
+
     if (ctx.res) destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_OPERATOR_ERRORS, ctx.res);
 
     const operators = await fetchOperators({ adminAreaCodes: session.adminAreaCodes ?? ["undefined"] });

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -268,8 +268,6 @@ export const getServerSideProps = async (
         consequence && isOperatorConsequence(consequence) ? consequence : undefined,
     );
 
-    const consequenceOperators = pageState.inputs.consequenceOperators;
-
     if (ctx.res) destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_OPERATOR_ERRORS, ctx.res);
 
     const operators = await fetchOperators({ adminAreaCodes: session.adminAreaCodes ?? ["undefined"] });

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -28,7 +28,7 @@ import { Operator, OperatorConsequence, operatorConsequenceSchema } from "../../
 import { isOperatorConsequence } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";
-import { getStateUpdater } from "../../../utils/formUtils";
+import { getStateUpdater, operatorStateUpdater } from "../../../utils/formUtils";
 
 const title = "Create Consequence Operator";
 const description = "Create Consequence Operator page for the Create Transport Disruptions Service";
@@ -43,6 +43,8 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
     const [pageState, setConsequenceOperatorPageState] = useState<PageState<Partial<OperatorConsequence>>>(props);
 
     const stateUpdater = getStateUpdater(setConsequenceOperatorPageState, pageState);
+
+    const operatorStateUpdate = operatorStateUpdater(setConsequenceOperatorPageState, pageState);
 
     const queryParams = useRouter().query;
     const displayCancelButton =
@@ -88,51 +90,59 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                             displaySize="l"
                         />
 
-                        <OperatorSearch
+                        <OperatorSearch<OperatorConsequence>
                             display="Operators impacted"
                             displaySize="l"
                             operators={props.operators.filter(
                                 (op) =>
                                     !(pageState.inputs.consequenceOperators || []).find(
-                                        (selOp) => selOp === op.nocCode,
+                                        (selOp) => selOp.operatorNoc === op.nocCode,
                                     ),
                             )}
-                            selectedOperatorNocs={pageState.inputs.consequenceOperators || []}
-                            stateUpdater={stateUpdater}
+                            selectedOperators={pageState.inputs.consequenceOperators || []}
+                            stateUpdater={operatorStateUpdate}
                             initialErrors={pageState.inputs.consequenceOperators?.length === 0 ? pageState.errors : []}
                             inputName="consequenceOperators"
                         />
 
                         {pageState.inputs.consequenceOperators && pageState.inputs.consequenceOperators.length > 0 ? (
                             <Table
-                                rows={pageState.inputs.consequenceOperators.map((selOpNoc) => {
-                                    return {
-                                        cells: [
-                                            props.operators.find((op) => op.nocCode === selOpNoc)?.operatorPublicName,
-                                            selOpNoc,
-                                            <button
-                                                key={selOpNoc}
-                                                className="govuk-link"
-                                                onClick={() => {
-                                                    const selectedOperatorsWithRemoved =
-                                                        pageState.inputs.consequenceOperators?.filter(
-                                                            (opNoc) => opNoc !== selOpNoc,
-                                                        ) || [];
-                                                    stateUpdater(selectedOperatorsWithRemoved, "consequenceOperators");
-                                                }}
-                                            >
-                                                Remove
-                                            </button>,
-                                        ],
-                                    };
-                                })}
+                                rows={pageState.inputs.consequenceOperators
+                                    .sort((a, b) => {
+                                        return a.operatorPublicName.localeCompare(b.operatorPublicName);
+                                    })
+                                    .map((selOpNoc) => {
+                                        return {
+                                            cells: [
+                                                props.operators.find((op) => op.nocCode === selOpNoc.operatorNoc)
+                                                    ?.operatorPublicName,
+                                                selOpNoc.operatorNoc,
+                                                <button
+                                                    key={selOpNoc.operatorNoc}
+                                                    className="govuk-link"
+                                                    onClick={() => {
+                                                        const selectedOperatorsWithRemoved =
+                                                            pageState.inputs.consequenceOperators?.filter(
+                                                                (opNoc) => opNoc.operatorNoc !== selOpNoc.operatorNoc,
+                                                            ) || [];
+                                                        operatorStateUpdate(
+                                                            selectedOperatorsWithRemoved,
+                                                            "consequenceOperators",
+                                                        );
+                                                    }}
+                                                >
+                                                    Remove
+                                                </button>,
+                                            ],
+                                        };
+                                    })}
                             />
                         ) : null}
 
                         <input
                             type="hidden"
                             name="consequenceOperators"
-                            value={pageState.inputs.consequenceOperators}
+                            value={JSON.stringify(pageState.inputs.consequenceOperators)}
                         />
 
                         <TextInput<OperatorConsequence>

--- a/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
+++ b/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
@@ -293,13 +293,11 @@ exports[`pages > CreateConsequenceOperator > should render correctly with inputs
               >
                 <td
                   className="govuk-table__cell align-middle"
-                >
-                  1st Choice Transport Ltd
-                </td>
+                />
                 <td
                   className="govuk-table__cell align-middle"
                 >
-                  1CTL
+                  FMAN
                 </td>
                 <td
                   className="govuk-table__cell align-middle"
@@ -317,11 +315,7 @@ exports[`pages > CreateConsequenceOperator > should render correctly with inputs
           <input
             name="consequenceOperators"
             type="hidden"
-            value={
-              [
-                "1CTL",
-              ]
-            }
+            value="[{\\"operatorNoc\\":\\"FMAN\\",\\"operatorPublicName\\":\\"Another operator\\"}]"
           />
           <div
             className="govuk-form-group"
@@ -1728,13 +1722,11 @@ exports[`pages > CreateConsequenceOperator > should render correctly with query 
               >
                 <td
                   className="govuk-table__cell align-middle"
-                >
-                  1st Choice Transport Ltd
-                </td>
+                />
                 <td
                   className="govuk-table__cell align-middle"
                 >
-                  1CTL
+                  FMAN
                 </td>
                 <td
                   className="govuk-table__cell align-middle"
@@ -1752,11 +1744,7 @@ exports[`pages > CreateConsequenceOperator > should render correctly with query 
           <input
             name="consequenceOperators"
             type="hidden"
-            value={
-              [
-                "1CTL",
-              ]
-            }
+            value="[{\\"operatorNoc\\":\\"FMAN\\",\\"operatorPublicName\\":\\"Another operator\\"}]"
           />
           <div
             className="govuk-form-group"

--- a/site/pages/create-consequence-operator/create-consequence-operator.test.tsx
+++ b/site/pages/create-consequence-operator/create-consequence-operator.test.tsx
@@ -2,8 +2,8 @@ import { Severity } from "@create-disruptions-data/shared-ts/enums";
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import CreateConsequenceOperator, { CreateConsequenceOperatorProps } from "./[disruptionId]/[consequenceIndex].page";
-import { mockOperators } from "../../testData/mockData";
 import { ConsequenceOperators } from "../../schemas/consequence.schema";
+import { mockOperators } from "../../testData/mockData";
 
 const blankInputs: CreateConsequenceOperatorProps = {
     errors: [],

--- a/site/pages/create-consequence-operator/create-consequence-operator.test.tsx
+++ b/site/pages/create-consequence-operator/create-consequence-operator.test.tsx
@@ -3,6 +3,7 @@ import renderer from "react-test-renderer";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import CreateConsequenceOperator, { CreateConsequenceOperatorProps } from "./[disruptionId]/[consequenceIndex].page";
 import { mockOperators } from "../../testData/mockData";
+import { ConsequenceOperators } from "../../schemas/consequence.schema";
 
 const blankInputs: CreateConsequenceOperatorProps = {
     errors: [],
@@ -10,10 +11,17 @@ const blankInputs: CreateConsequenceOperatorProps = {
     operators: mockOperators,
 };
 
+const defaultConsequenceOperators: ConsequenceOperators[] = [
+    {
+        operatorNoc: "FMAN",
+        operatorPublicName: "Another operator",
+    },
+];
+
 const withInputs: CreateConsequenceOperatorProps = {
     errors: [],
     inputs: {
-        consequenceOperators: ["1CTL"],
+        consequenceOperators: defaultConsequenceOperators,
         description: "A truck broke down on a bridge",
         removeFromJourneyPlanners: "yes",
         disruptionDelay: "yes",

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -473,9 +473,9 @@ const DisruptionDetail = ({
                                                         ? "Stops"
                                                         : consequence.consequenceType === "operatorWide" &&
                                                           consequence.consequenceOperators
-                                                        ? `Operator wide - ${consequence.consequenceOperators.join(
-                                                              ", ",
-                                                          )}`
+                                                        ? `Operator wide - ${consequence.consequenceOperators
+                                                              .map((operator) => operator.operatorNoc)
+                                                              .join(", ")}`
                                                         : `${"Network wide"}`
                                                 }`}
                                             </span>

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -625,7 +625,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                     className="govuk-accordion__section-button"
                     id="accordion-default-heading-2"
                   >
-                    Consequence 2 - Tram - Operator wide - FSYO
+                    Consequence 2 - Tram - Operator wide - 
                   </span>
                 </h2>
               </div>
@@ -714,9 +714,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                       </th>
                       <td
                         className="govuk-table__cell align-middle"
-                      >
-                        FSYO
-                      </td>
+                      />
                       <td
                         className="govuk-table__cell align-middle"
                       >
@@ -2428,7 +2426,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                     className="govuk-accordion__section-button"
                     id="accordion-default-heading-2"
                   >
-                    Consequence 2 - Tram - Operator wide - FSYO
+                    Consequence 2 - Tram - Operator wide - 
                   </span>
                 </h2>
               </div>
@@ -2517,9 +2515,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                       </th>
                       <td
                         className="govuk-table__cell align-middle"
-                      >
-                        FSYO
-                      </td>
+                      />
                       <td
                         className="govuk-table__cell align-middle"
                       >

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -625,7 +625,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                     className="govuk-accordion__section-button"
                     id="accordion-default-heading-2"
                   >
-                    Consequence 2 - Tram - Operator wide - 
+                    Consequence 2 - Tram - Operator wide - FMAN
                   </span>
                 </h2>
               </div>
@@ -714,7 +714,9 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                       </th>
                       <td
                         className="govuk-table__cell align-middle"
-                      />
+                      >
+                        FMAN
+                      </td>
                       <td
                         className="govuk-table__cell align-middle"
                       >
@@ -2426,7 +2428,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                     className="govuk-accordion__section-button"
                     id="accordion-default-heading-2"
                   >
-                    Consequence 2 - Tram - Operator wide - 
+                    Consequence 2 - Tram - Operator wide - FMAN
                   </span>
                 </h2>
               </div>
@@ -2515,7 +2517,9 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                       </th>
                       <td
                         className="govuk-table__cell align-middle"
-                      />
+                      >
+                        FMAN
+                      </td>
                       <td
                         className="govuk-table__cell align-middle"
                       >

--- a/site/pages/disruption-detail/disruption-detail.test.tsx
+++ b/site/pages/disruption-detail/disruption-detail.test.tsx
@@ -9,8 +9,15 @@ import { render } from "@testing-library/react";
 import renderer from "react-test-renderer";
 import { describe, it, expect } from "vitest";
 import DisruptionDetail from "./[disruptionId].page";
-import { Consequence } from "../../schemas/consequence.schema";
+import { Consequence, ConsequenceOperators } from "../../schemas/consequence.schema";
 import { Disruption } from "../../schemas/disruption.schema";
+
+const defaultConsequenceOperators: ConsequenceOperators[] = [
+    {
+        operatorNoc: "FMAN",
+        operatorPublicName: "Another operator",
+    },
+];
 
 const previousConsequencesInformation: Consequence[] = [
     {
@@ -28,7 +35,7 @@ const previousConsequencesInformation: Consequence[] = [
         consequenceType: "operatorWide",
         consequenceIndex: 1,
         disruptionId: "1",
-        consequenceOperators: ["FSYO"],
+        consequenceOperators: defaultConsequenceOperators,
         description: "The road is closed for the following reasons: Example, example, example, example",
         removeFromJourneyPlanners: "yes",
         disruptionDelay: "50",

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -420,9 +420,9 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
                                                         ? "Stops"
                                                         : consequence.consequenceType === "operatorWide" &&
                                                           consequence.consequenceOperators
-                                                        ? `Operator wide - ${consequence.consequenceOperators.join(
-                                                              ", ",
-                                                          )}`
+                                                        ? `Operator wide - ${consequence.consequenceOperators
+                                                              .map((operator) => operator.operatorNoc)
+                                                              .join(", ")}`
                                                         : `${"Network wide"}`
                                                 }`}
                                             </span>

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -611,7 +611,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                     className="govuk-accordion__section-button"
                     id="accordion-default-heading-2"
                   >
-                    Consequence 2 - Tram - Operator wide - FSYO
+                    Consequence 2 - Tram - Operator wide - 
                   </span>
                 </h2>
               </div>
@@ -700,9 +700,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       </th>
                       <td
                         className="govuk-table__cell align-middle"
-                      >
-                        FSYO
-                      </td>
+                      />
                       <td
                         className="govuk-table__cell align-middle"
                       >

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -611,7 +611,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                     className="govuk-accordion__section-button"
                     id="accordion-default-heading-2"
                   >
-                    Consequence 2 - Tram - Operator wide - 
+                    Consequence 2 - Tram - Operator wide - FMAN
                   </span>
                 </h2>
               </div>
@@ -700,7 +700,9 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       </th>
                       <td
                         className="govuk-table__cell align-middle"
-                      />
+                      >
+                        FMAN
+                      </td>
                       <td
                         className="govuk-table__cell align-middle"
                       >

--- a/site/pages/review-disruption/review-disruption.test.tsx
+++ b/site/pages/review-disruption/review-disruption.test.tsx
@@ -9,10 +9,17 @@ import { render } from "@testing-library/react";
 import renderer from "react-test-renderer";
 import { describe, it, expect } from "vitest";
 import ReviewDisruption from "./[disruptionId].page";
-import { Consequence } from "../../schemas/consequence.schema";
+import { Consequence, ConsequenceOperators } from "../../schemas/consequence.schema";
 import { Disruption } from "../../schemas/disruption.schema";
 
 const defaultDisruptionId = "acde070d-8c4c-4f0d-9d8a-162843c10333";
+
+const defaultConsequenceOperators: ConsequenceOperators[] = [
+    {
+        operatorNoc: "FMAN",
+        operatorPublicName: "Another operator",
+    },
+];
 
 const previousConsequencesInformation: Consequence[] = [
     {
@@ -30,7 +37,7 @@ const previousConsequencesInformation: Consequence[] = [
         consequenceType: "operatorWide",
         consequenceIndex: 1,
         disruptionId: defaultDisruptionId,
-        consequenceOperators: ["FSYO"],
+        consequenceOperators: defaultConsequenceOperators,
         description: "The road is closed for the following reasons: Example, example, example, example",
         removeFromJourneyPlanners: "yes",
         disruptionDelay: "50",

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -365,11 +365,11 @@ const ViewAllDisruptions = ({
     );
     const [currentPage, setCurrentPage] = useState(1);
     const [selectedServices, setSelectedServices] = useState<Service[]>([]);
-    const [selectedOperatorsNocs, setSelectedOperatorsNocs] = useState<string[]>([]);
+    const [selectedOperators, setSelectedOperators] = useState<ConsequenceOperators[]>([]);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const stateUpdater = (change: string[] | ConsequenceOperators[], _field: string): void => {
-        setSelectedOperatorsNocs(change as string[]);
+    const stateUpdater = (change: ConsequenceOperators[], _field: string): void => {
+        setSelectedOperators([...change]);
     };
     const [filter, setFilter] = useState<Filter>({
         services: [],
@@ -458,7 +458,7 @@ const ViewAllDisruptions = ({
             setStartDateFilterError(false);
             setEndDateFilter("");
             setEndDateFilterError(false);
-            setSelectedOperatorsNocs([]);
+            setSelectedOperators([]);
             setSelectedServices([]);
             setClearButtonClicked(false);
             setSearchText("");
@@ -508,8 +508,8 @@ const ViewAllDisruptions = ({
 
     useEffect(() => {
         const disruptionOperatorsToSet: DisruptionOperator[] = [];
-        selectedOperatorsNocs.forEach((selOpNoc) => {
-            const operator = operatorsList.find((op) => op.nocCode === selOpNoc);
+        selectedOperators.forEach((selOpNoc) => {
+            const operator = operatorsList.find((op) => op.nocCode === selOpNoc.operatorNoc);
             if (operator) {
                 disruptionOperatorsToSet.push({
                     operatorName: operator.operatorPublicName,
@@ -529,7 +529,7 @@ const ViewAllDisruptions = ({
             { ...filter, operators: disruptionOperatorsToSet },
             setNumberOfDisruptionsPages,
         ); // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedOperatorsNocs]);
+    }, [selectedOperators]);
 
     useEffect(() => {
         if (filterIsEmpty(filter)) {
@@ -749,37 +749,42 @@ const ViewAllDisruptions = ({
                             />
                         </div>
                     </div>
-                    <OperatorSearch
+                    <OperatorSearch<DisruptionOperator>
                         display="Operators"
                         displaySize="s"
                         operators={operatorsList}
-                        selectedOperatorNocs={selectedOperatorsNocs}
+                        selectedOperators={selectedOperators}
                         stateUpdater={stateUpdater}
                         initialErrors={[]}
-                        inputName="operatorsFilter"
+                        inputName="operatorName"
                         reset={clearButtonClicked}
                     />
-                    {selectedOperatorsNocs.length > 0 ? (
+                    {selectedOperators.length > 0 ? (
                         <Table
-                            rows={selectedOperatorsNocs.map((selOpNoc) => {
-                                return {
-                                    cells: [
-                                        operatorsList.find((op) => op.nocCode === selOpNoc)?.operatorPublicName,
-                                        selOpNoc,
-                                        <button
-                                            key={selOpNoc}
-                                            className="govuk-link"
-                                            onClick={() => {
-                                                const selectedOperatorsWithRemoved =
-                                                    selectedOperatorsNocs.filter((opNoc) => opNoc !== selOpNoc) || [];
-                                                stateUpdater(selectedOperatorsWithRemoved, "");
-                                            }}
-                                        >
-                                            Remove
-                                        </button>,
-                                    ],
-                                };
-                            })}
+                            rows={selectedOperators
+                                .sort((a, b) => {
+                                    return a.operatorPublicName.localeCompare(b.operatorPublicName);
+                                })
+                                .map((selOpNoc) => {
+                                    return {
+                                        cells: [
+                                            operatorsList.find((op) => op.nocCode === selOpNoc.operatorNoc)
+                                                ?.operatorPublicName,
+                                            selOpNoc.operatorNoc,
+                                            <button
+                                                key={selOpNoc.operatorNoc}
+                                                className="govuk-link"
+                                                onClick={() => {
+                                                    const selectedOperatorsWithRemoved =
+                                                        selectedOperators.filter((opNoc) => opNoc !== selOpNoc) || [];
+                                                    stateUpdater(selectedOperatorsWithRemoved, "");
+                                                }}
+                                            >
+                                                Remove
+                                            </button>,
+                                        ],
+                                    };
+                                })}
                         />
                     ) : null}
                     <ServiceSearch

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -30,7 +30,7 @@ import {
 } from "../constants";
 import { getDisruptionsDataFromDynamo } from "../data/dynamo";
 import { fetchOperators, fetchServices } from "../data/refDataApi";
-import { Operator, Service } from "../schemas/consequence.schema";
+import { ConsequenceOperators, Operator, Service } from "../schemas/consequence.schema";
 import { validitySchema } from "../schemas/create-disruption.schema";
 import { exportDisruptionsSchema, ExportDisruptionData } from "../schemas/disruption.schema";
 import {
@@ -368,8 +368,8 @@ const ViewAllDisruptions = ({
     const [selectedOperatorsNocs, setSelectedOperatorsNocs] = useState<string[]>([]);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const stateUpdater = (change: string[], _field: string): void => {
-        setSelectedOperatorsNocs(change);
+    const stateUpdater = (change: string[] | ConsequenceOperators[], _field: string): void => {
+        setSelectedOperatorsNocs(change as string[]);
     };
     const [filter, setFilter] = useState<Filter>({
         services: [],

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -998,7 +998,7 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
                     } else if (consequence.consequenceType === "operatorWide") {
                         isOperatorWideCq = true;
                         consequence.consequenceOperators.forEach((op) => {
-                            disruptionOperators.push(op);
+                            disruptionOperators.push(op.operatorNoc);
                         });
                     } else if (consequence.consequenceType === "networkWide") {
                         isNetworkWideCq = true;

--- a/site/schemas/consequence.schema.ts
+++ b/site/schemas/consequence.schema.ts
@@ -19,11 +19,18 @@ export const networkConsequenceSchema = z.object({
     consequenceType: z.literal("networkWide", setZodDefaultError("Select a consequence type")),
 });
 
+export const consequenceOperatorsSchema = z.object({
+    operatorNoc: z.string(),
+    operatorPublicName: z.string(),
+});
+
+export type ConsequenceOperators = z.infer<typeof consequenceOperatorsSchema>;
+
 export type NetworkConsequence = z.infer<typeof networkConsequenceSchema>;
 
 export const operatorConsequenceSchema = z.object({
     ...baseConsequence,
-    consequenceOperators: z.array(z.string()).min(1, { message: "Select one or more operators" }),
+    consequenceOperators: z.array(consequenceOperatorsSchema).min(1, { message: "Select one or more operators" }),
     consequenceType: z.literal("operatorWide", setZodDefaultError("Select a consequence type")),
 });
 

--- a/site/testData/mockData.ts
+++ b/site/testData/mockData.ts
@@ -458,7 +458,7 @@ export const ptSituationElementWithMultipleConsequences = {
                 Severity: "severe",
                 Affects: {
                     Networks: { AffectedNetwork: { VehicleMode: "bus", AllLines: "" } },
-                    Operators: { AffectedOperator: [{ OperatorRef: "FSYO" }] },
+                    Operators: { AffectedOperator: [{ OperatorRef: "FSYO", OperatorName: "Operator Name" }] },
                 },
                 Advice: { Details: "Some consequence description" },
                 Blocking: { JourneyPlanner: true },

--- a/site/testData/mockData.ts
+++ b/site/testData/mockData.ts
@@ -131,7 +131,7 @@ export const getMockContext = ({
 
 export interface GetMockRequestAndResponse {
     cookieValues?: Record<string, string>;
-    body?: Record<string, string | string[] | RecordType> | null;
+    body?: Record<string, string | string[] | RecordType | RecordType[]> | null;
     uuid?: string | null;
     mockWriteHeadFn?: Mock | null;
     mockEndFn?: Mock | null;
@@ -353,7 +353,7 @@ export const consequenceInfoOperatorTest: Consequence = {
     consequenceIndex: 0,
     disruptionId: "acde070d-8c4c-4f0d-9d8a-162843c10333",
     consequenceType: "operatorWide",
-    consequenceOperators: ["FSYO"],
+    consequenceOperators: [{ operatorNoc: "FSYO", operatorPublicName: "Operator Name" }],
     description: "Some consequence description",
     disruptionSeverity: Severity.severe,
     vehicleMode: VehicleMode.bus,

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -44,7 +44,7 @@ export const getStateUpdater =
 
 export const operatorStateUpdater =
     <T>(setter: (value: SetStateAction<PageState<Partial<T>>>) => void, state: PageState<Partial<T>>) =>
-    (change: string | string[] | ConsequenceOperators[], field: keyof T) => {
+    (change: ConsequenceOperators[], field: keyof T) => {
         setter({
             ...state,
             inputs: {

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from "react";
 import { z } from "zod";
 import { ErrorInfo, PageState } from "../interfaces";
-import { Service, Stop } from "../schemas/consequence.schema";
+import { ConsequenceOperators, Service, Stop } from "../schemas/consequence.schema";
 import { sortServices } from ".";
 
 export const handleBlur = <T>(
@@ -33,6 +33,18 @@ export const handleBlur = <T>(
 export const getStateUpdater =
     <T>(setter: (value: SetStateAction<PageState<Partial<T>>>) => void, state: PageState<Partial<T>>) =>
     (change: string | string[], field: keyof T) => {
+        setter({
+            ...state,
+            inputs: {
+                ...state.inputs,
+                [field]: change,
+            },
+        });
+    };
+
+export const operatorStateUpdater =
+    <T>(setter: (value: SetStateAction<PageState<Partial<T>>>) => void, state: PageState<Partial<T>>) =>
+    (change: ConsequenceOperators[], field: keyof T) => {
         setter({
             ...state,
             inputs: {

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -44,7 +44,7 @@ export const getStateUpdater =
 
 export const operatorStateUpdater =
     <T>(setter: (value: SetStateAction<PageState<Partial<T>>>) => void, state: PageState<Partial<T>>) =>
-    (change: ConsequenceOperators[], field: keyof T) => {
+    (change: string | string[] | ConsequenceOperators[], field: keyof T) => {
         setter({
             ...state,
             inputs: {

--- a/site/utils/index.test.ts
+++ b/site/utils/index.test.ts
@@ -61,7 +61,7 @@ describe("page state test", () => {
         const operatorData: OperatorConsequence = {
             disruptionId: randomUUID(),
             consequenceIndex: 0,
-            consequenceOperators: ["FMAN"],
+            consequenceOperators: [{ operatorNoc: "FSYO", operatorPublicName: "Operator Name" }],
             description:
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
             removeFromJourneyPlanners: "no",

--- a/site/utils/siri.ts
+++ b/site/utils/siri.ts
@@ -140,8 +140,9 @@ export const getPtSituationElementFromDraft = (disruption: Disruption) => {
                               ...(consequence.consequenceType === "operatorWide"
                                   ? {
                                         Operators: {
-                                            AffectedOperator: consequence.consequenceOperators.map((operatorNoc) => ({
-                                                OperatorRef: operatorNoc,
+                                            AffectedOperator: consequence.consequenceOperators.map((operator) => ({
+                                                OperatorRef: operator.operatorNoc,
+                                                OperatorName: operator.operatorPublicName,
                                             })),
                                         },
                                     }


### PR DESCRIPTION
Testing instructions

- Create new disruptions or update existing disruptions with consequences of type operators. Publish the disruptions
- Pull the Siri SX XML using the API which should contain <OperatorName/> field for consequences with type Operators