### PR TITLE
feat: Now button on create disruption page

### DIFF
--- a/site/components/form/DateSelector.tsx
+++ b/site/components/form/DateSelector.tsx
@@ -22,6 +22,7 @@ interface DateSelectorProps<T> extends FormBase<T> {
     reset?: boolean;
     errorOnBlur?: boolean;
     suffixId?: string;
+    resetError?: boolean;
 }
 
 const inputBox = <T extends object>(
@@ -90,6 +91,7 @@ const DateSelector = <T extends object>({
     reset = false,
     errorOnBlur = true,
     suffixId,
+    resetError = false,
 }: DateSelectorProps<T>): ReactElement => {
     const [dateValue, setDateValue] = useState<Date | null>(
         !!disabled || !value ? null : getFormattedDate(value).toDate(),
@@ -103,6 +105,18 @@ const DateSelector = <T extends object>({
             setDateValue(null);
         }
     }, [disabled, reset]);
+
+    useEffect(() => {
+        if (resetError) {
+            setErrors([]);
+        }
+    }, [resetError]);
+
+    useEffect(() => {
+        if (value) {
+            setDateValue(getFormattedDate(value).toDate());
+        }
+    }, [value]);
 
     useEffect(() => {
         setErrors(initialErrors);

--- a/site/components/form/TimeSelector.tsx
+++ b/site/components/form/TimeSelector.tsx
@@ -89,7 +89,7 @@ const TimeSelector = <T extends object>({
                         />
                     </FormElementWrapper>
                     {showNowButton ? (
-                        <button className="mt-3 govuk-link h-5" data-module="govuk-button" onClick={showNowButton}>
+                        <button className="mt-3 govuk-link h-6" data-module="govuk-button" onClick={showNowButton}>
                             <p className="text-govBlue govuk-body-m">Now</p>
                         </button>
                     ) : null}

--- a/site/components/form/TimeSelector.tsx
+++ b/site/components/form/TimeSelector.tsx
@@ -1,5 +1,5 @@
 import kebabCase from "lodash/kebabCase";
-import { ReactElement, useEffect, useRef, useState } from "react";
+import { ReactElement, SyntheticEvent, useEffect, useRef, useState } from "react";
 import FormElementWrapper, { FormGroupWrapper } from "./FormElementWrapper";
 import { ErrorInfo, FormBase } from "../../interfaces";
 import { handleBlur } from "../../utils/formUtils";
@@ -9,6 +9,8 @@ interface TimeSelectorProps<T> extends FormBase<T> {
     hint?: string;
     reset?: boolean;
     placeholderValue?: string;
+    resetError?: boolean;
+    showNowButton?: (e: SyntheticEvent) => void;
 }
 
 const TimeSelector = <T extends object>({
@@ -23,6 +25,8 @@ const TimeSelector = <T extends object>({
     stateUpdater,
     reset = false,
     placeholderValue = "hhmm",
+    resetError = false,
+    showNowButton = false,
 }: TimeSelectorProps<T>): ReactElement => {
     const [errors, setErrors] = useState<ErrorInfo[]>(initialErrors);
     const ref = useRef<HTMLInputElement>(null);
@@ -39,6 +43,20 @@ const TimeSelector = <T extends object>({
     }, [disabled, reset]);
 
     useEffect(() => {
+        if (resetError) {
+            setErrors([]);
+        }
+    }, [resetError]);
+
+    useEffect(() => {
+        if (value) {
+            if (ref.current) {
+                ref.current.value = value;
+            }
+        }
+    }, [value]);
+
+    useEffect(() => {
         setErrors(initialErrors);
     }, [initialErrors]);
 
@@ -53,20 +71,29 @@ const TimeSelector = <T extends object>({
                         {hint}
                     </div>
                 ) : null}
-                <FormElementWrapper errors={errors} errorId={inputName} errorClass="govuk-input--error">
-                    <input
-                        ref={ref}
-                        className="govuk-input govuk-date-input__input govuk-input--width-4"
-                        name={inputName}
-                        id={`${inputId}-input`}
-                        type="text"
-                        defaultValue={value}
-                        disabled={disabled}
-                        placeholder={disabled ? "N/A" : placeholderValue}
-                        aria-describedby={hint ? `${inputId}-hint` : ""}
-                        onBlur={(e) => handleBlur(e.target.value, inputName, stateUpdater, setErrors, schema, disabled)}
-                    />
-                </FormElementWrapper>
+                <div className={!!showNowButton ? "flex gap-4" : ""}>
+                    <FormElementWrapper errors={errors} errorId={inputName} errorClass="govuk-input--error">
+                        <input
+                            ref={ref}
+                            className="govuk-input govuk-date-input__input govuk-input--width-4"
+                            name={inputName}
+                            id={`${inputId}-input`}
+                            type="text"
+                            defaultValue={value}
+                            disabled={disabled}
+                            placeholder={disabled ? "N/A" : placeholderValue}
+                            aria-describedby={hint ? `${inputId}-hint` : ""}
+                            onBlur={(e) =>
+                                handleBlur(e.target.value, inputName, stateUpdater, setErrors, schema, disabled)
+                            }
+                        />
+                    </FormElementWrapper>
+                    {showNowButton ? (
+                        <button className="mt-3 govuk-link" data-module="govuk-button" onClick={showNowButton}>
+                            <p className="text-govBlue govuk-body-m">Now</p>
+                        </button>
+                    ) : null}
+                </div>
             </div>
         </FormGroupWrapper>
     );

--- a/site/components/form/TimeSelector.tsx
+++ b/site/components/form/TimeSelector.tsx
@@ -26,7 +26,7 @@ const TimeSelector = <T extends object>({
     reset = false,
     placeholderValue = "hhmm",
     resetError = false,
-    showNowButton = false,
+    showNowButton,
 }: TimeSelectorProps<T>): ReactElement => {
     const [errors, setErrors] = useState<ErrorInfo[]>(initialErrors);
     const ref = useRef<HTMLInputElement>(null);

--- a/site/components/form/TimeSelector.tsx
+++ b/site/components/form/TimeSelector.tsx
@@ -89,7 +89,7 @@ const TimeSelector = <T extends object>({
                         />
                     </FormElementWrapper>
                     {showNowButton ? (
-                        <button className="mt-3 govuk-link" data-module="govuk-button" onClick={showNowButton}>
+                        <button className="mt-3 govuk-link h-5" data-module="govuk-button" onClick={showNowButton}>
                             <p className="text-govBlue govuk-body-m">Now</p>
                         </button>
                     ) : null}

--- a/site/components/form/__snapshots__/TimeSelector.test.tsx.snap
+++ b/site/components/form/__snapshots__/TimeSelector.test.tsx.snap
@@ -17,17 +17,21 @@ exports[`TimeSelector > should render correctly when disabled 1`] = `
     <div
       className=""
     >
-      <input
-        aria-describedby=""
-        className="govuk-input govuk-date-input__input govuk-input--width-4"
-        defaultValue="three thirty"
-        disabled={true}
-        id="field-1-input"
-        name="field1"
-        onBlur={[Function]}
-        placeholder="N/A"
-        type="text"
-      />
+      <div
+        className=""
+      >
+        <input
+          aria-describedby=""
+          className="govuk-input govuk-date-input__input govuk-input--width-4"
+          defaultValue="three thirty"
+          disabled={true}
+          id="field-1-input"
+          name="field1"
+          onBlur={[Function]}
+          placeholder="N/A"
+          type="text"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -56,17 +60,21 @@ exports[`TimeSelector > should render correctly with errors 1`] = `
     <div
       className=""
     >
-      <input
-        aria-describedby="field-1-hint"
-        className="govuk-input govuk-date-input__input govuk-input--width-4"
-        defaultValue="three thirty"
-        disabled={false}
-        id="field-1-input"
-        name="field1"
-        onBlur={[Function]}
-        placeholder="hhmm"
-        type="text"
-      />
+      <div
+        className=""
+      >
+        <input
+          aria-describedby="field-1-hint"
+          className="govuk-input govuk-date-input__input govuk-input--width-4"
+          defaultValue="three thirty"
+          disabled={false}
+          id="field-1-input"
+          name="field1"
+          onBlur={[Function]}
+          placeholder="hhmm"
+          type="text"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -89,17 +97,21 @@ exports[`TimeSelector > should render correctly with inputs 1`] = `
     <div
       className=""
     >
-      <input
-        aria-describedby=""
-        className="govuk-input govuk-date-input__input govuk-input--width-4"
-        defaultValue="0900"
-        disabled={false}
-        id="field-1-input"
-        name="field1"
-        onBlur={[Function]}
-        placeholder="hhmm"
-        type="text"
-      />
+      <div
+        className=""
+      >
+        <input
+          aria-describedby=""
+          className="govuk-input govuk-date-input__input govuk-input--width-4"
+          defaultValue="0900"
+          disabled={false}
+          id="field-1-input"
+          name="field1"
+          onBlur={[Function]}
+          placeholder="hhmm"
+          type="text"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -122,17 +134,21 @@ exports[`TimeSelector > should render correctly with no inputs 1`] = `
     <div
       className=""
     >
-      <input
-        aria-describedby=""
-        className="govuk-input govuk-date-input__input govuk-input--width-4"
-        defaultValue=""
-        disabled={false}
-        id="field-1-input"
-        name="field1"
-        onBlur={[Function]}
-        placeholder="hhmm"
-        type="text"
-      />
+      <div
+        className=""
+      >
+        <input
+          aria-describedby=""
+          className="govuk-input govuk-date-input__input govuk-input--width-4"
+          defaultValue=""
+          disabled={false}
+          id="field-1-input"
+          name="field1"
+          onBlur={[Function]}
+          placeholder="hhmm"
+          type="text"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/site/pages/create-consequence-network/__snapshots__/create-consequence-network.test.tsx.snap
+++ b/site/pages/create-consequence-network/__snapshots__/create-consequence-network.test.tsx.snap
@@ -277,17 +277,21 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with inputs 
               <div
                 className=""
               >
-                <input
-                  aria-describedby=""
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="yes"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby=""
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="yes"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -851,16 +855,20 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with no inpu
               <div
                 className=""
               >
-                <input
-                  aria-describedby=""
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby=""
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -1424,17 +1432,21 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with query p
               <div
                 className=""
               >
-                <input
-                  aria-describedby=""
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="yes"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby=""
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="yes"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
+++ b/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
@@ -443,17 +443,21 @@ exports[`pages > CreateConsequenceOperator > should render correctly with inputs
               <div
                 className=""
               >
-                <input
-                  aria-describedby=""
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="yes"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby=""
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="yes"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -1139,16 +1143,20 @@ exports[`pages > CreateConsequenceOperator > should render correctly with no inp
               <div
                 className=""
               >
-                <input
-                  aria-describedby=""
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby=""
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -1878,17 +1886,21 @@ exports[`pages > CreateConsequenceOperator > should render correctly with query 
               <div
                 className=""
               >
-                <input
-                  aria-describedby=""
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="yes"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby=""
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="yes"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/site/pages/create-consequence-services/__snapshots__/create-consequence-services.test.tsx.snap
+++ b/site/pages/create-consequence-services/__snapshots__/create-consequence-services.test.tsx.snap
@@ -690,17 +690,21 @@ exports[`pages > CreateConsequenceServices > should render correctly with errors
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="45"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="45"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -1709,17 +1713,21 @@ exports[`pages > CreateConsequenceServices > should render correctly with inputs
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="45"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="45"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -2651,16 +2659,20 @@ exports[`pages > CreateConsequenceServices > should render correctly with no inp
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -3669,17 +3681,21 @@ exports[`pages > CreateConsequenceServices > should render correctly with query 
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="45"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="45"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/site/pages/create-consequence-stops/__snapshots__/create-consequence-stops.test.tsx.snap
+++ b/site/pages/create-consequence-stops/__snapshots__/create-consequence-stops.test.tsx.snap
@@ -523,17 +523,21 @@ exports[`pages > CreateConsequenceStops > should render correctly with errors an
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="45"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="45"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -1285,17 +1289,21 @@ exports[`pages > CreateConsequenceStops > should render correctly with inputs 1`
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="45"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="45"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -1996,16 +2004,20 @@ exports[`pages > CreateConsequenceStops > should render correctly with no inputs
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -2757,17 +2769,21 @@ exports[`pages > CreateConsequenceStops > should render correctly with query par
               <div
                 className=""
               >
-                <input
-                  aria-describedby="disruption-delay-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="45"
-                  disabled={false}
-                  id="disruption-delay-input"
-                  name="disruptionDelay"
-                  onBlur={[Function]}
-                  placeholder=""
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="disruption-delay-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="45"
+                    disabled={false}
+                    id="disruption-delay-input"
+                    name="disruptionDelay"
+                    onBlur={[Function]}
+                    placeholder=""
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";

--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -31,7 +32,7 @@ import {
 import { flattenZodErrors } from "../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../utils/apiUtils";
 import { getSession } from "../../utils/apiUtils/auth";
-import { getEndingOnDateText } from "../../utils/dates";
+import { convertDateTimeToFormat, getEndingOnDateText } from "../../utils/dates";
 import { getStateUpdater } from "../../utils/formUtils";
 
 const title = "Create Disruptions";
@@ -191,6 +192,20 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
             [field]: change,
             disruptionNoEndDateTime: change === "daily" || change === "weekly" ? "" : validity.disruptionNoEndDateTime,
             disruptionRepeatsEndDate: "",
+        });
+    };
+
+    const handleNow = (e: SyntheticEvent) => {
+        e.preventDefault();
+        const dateTime = new Date();
+
+        setDisruptionPageState({
+            ...pageState,
+            inputs: {
+                ...pageState.inputs,
+                publishStartDate: convertDateTimeToFormat(dateTime, "DD/MM/YYYY"),
+                publishStartTime: convertDateTimeToFormat(dateTime, "HHmm"),
+            },
         });
     };
 
@@ -385,6 +400,10 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     stateUpdater={stateUpdater}
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishStartDate}
+                                    resetError={
+                                        pageState.inputs.publishStartDate ===
+                                        convertDateTimeToFormat(new Date(), "DD/MM/YYYY")
+                                    }
                                 />
                             </div>
                             <div className="pl-4">
@@ -397,6 +416,11 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     stateUpdater={stateUpdater}
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishStartTime}
+                                    resetError={
+                                        pageState.inputs.publishStartTime ===
+                                        convertDateTimeToFormat(new Date(), "HHmm")
+                                    }
+                                    showNowButton={handleNow}
                                 />
                             </div>
                         </div>

--- a/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
+++ b/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
@@ -587,17 +587,21 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby="disruption-start-time-hint"
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="0100"
-                      disabled={false}
-                      id="disruption-start-time-input"
-                      name="disruptionStartTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby="disruption-start-time-hint"
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="0100"
+                        disabled={false}
+                        id="disruption-start-time-input"
+                        name="disruptionStartTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -709,17 +713,21 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby=""
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="0200"
-                      disabled={false}
-                      id="disruption-end-time-input"
-                      name="disruptionEndTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby=""
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="0200"
+                        disabled={false}
+                        id="disruption-end-time-input"
+                        name="disruptionEndTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -882,19 +890,34 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                     Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm
                   </div>
                   <div
-                    className=""
+                    className="flex gap-4"
                   >
-                    <input
-                      aria-describedby="publish-start-time-hint"
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="0200"
-                      disabled={false}
-                      id="publish-start-time-input"
-                      name="publishStartTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby="publish-start-time-hint"
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="0200"
+                        disabled={false}
+                        id="publish-start-time-input"
+                        name="publishStartTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
+                    <button
+                      className="mt-3 govuk-link"
+                      data-module="govuk-button"
+                      onClick={[Function]}
+                    >
+                      <p
+                        className="text-govBlue govuk-body-m"
+                      >
+                        Now
+                      </p>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1006,17 +1029,21 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby=""
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="2300"
-                      disabled={false}
-                      id="publish-end-time-input"
-                      name="publishEndTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby=""
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="2300"
+                        disabled={false}
+                        id="publish-end-time-input"
+                        name="publishEndTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1131,7 +1158,7 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                                   onChange={[Function]}
                                   placeholder="DD/MM/YYYY"
                                   type="tel"
-                                  value=""
+                                  value="30/03/2023"
                                 />
                               </div>
                             </div>
@@ -1139,7 +1166,7 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                               className="MuiInputAdornment-root MuiInputAdornment-positionEnd css-1laqsz7-MuiInputAdornment-root"
                             >
                               <button
-                                aria-label="Choose date"
+                                aria-label="Choose date, selected date is Mar 30, 2023"
                                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1yq5fb3-MuiButtonBase-root-MuiIconButton-root"
                                 disabled={false}
                                 onBlur={[Function]}
@@ -2033,17 +2060,21 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby="disruption-start-time-hint"
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue=""
-                      disabled={false}
-                      id="disruption-start-time-input"
-                      name="disruptionStartTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby="disruption-start-time-hint"
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue=""
+                        disabled={false}
+                        id="disruption-start-time-input"
+                        name="disruptionStartTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -2152,17 +2183,21 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby=""
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue=""
-                      disabled={false}
-                      id="disruption-end-time-input"
-                      name="disruptionEndTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby=""
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue=""
+                        disabled={false}
+                        id="disruption-end-time-input"
+                        name="disruptionEndTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -2322,18 +2357,33 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                     Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm
                   </div>
                   <div
-                    className=""
+                    className="flex gap-4"
                   >
-                    <input
-                      aria-describedby="publish-start-time-hint"
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      disabled={false}
-                      id="publish-start-time-input"
-                      name="publishStartTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby="publish-start-time-hint"
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        disabled={false}
+                        id="publish-start-time-input"
+                        name="publishStartTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
+                    <button
+                      className="mt-3 govuk-link"
+                      data-module="govuk-button"
+                      onClick={[Function]}
+                    >
+                      <p
+                        className="text-govBlue govuk-body-m"
+                      >
+                        Now
+                      </p>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -2442,16 +2492,20 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby=""
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      disabled={false}
-                      id="publish-end-time-input"
-                      name="publishEndTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby=""
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        disabled={false}
+                        id="publish-end-time-input"
+                        name="publishEndTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -3522,17 +3576,21 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby="disruption-start-time-hint"
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="0100"
-                      disabled={false}
-                      id="disruption-start-time-input"
-                      name="disruptionStartTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby="disruption-start-time-hint"
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="0100"
+                        disabled={false}
+                        id="disruption-start-time-input"
+                        name="disruptionStartTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -3641,17 +3699,21 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby=""
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="0200"
-                      disabled={false}
-                      id="disruption-end-time-input"
-                      name="disruptionEndTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby=""
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="0200"
+                        disabled={false}
+                        id="disruption-end-time-input"
+                        name="disruptionEndTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -3811,19 +3873,34 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                     Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm
                   </div>
                   <div
-                    className=""
+                    className="flex gap-4"
                   >
-                    <input
-                      aria-describedby="publish-start-time-hint"
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="0200"
-                      disabled={false}
-                      id="publish-start-time-input"
-                      name="publishStartTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby="publish-start-time-hint"
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="0200"
+                        disabled={false}
+                        id="publish-start-time-input"
+                        name="publishStartTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
+                    <button
+                      className="mt-3 govuk-link"
+                      data-module="govuk-button"
+                      onClick={[Function]}
+                    >
+                      <p
+                        className="text-govBlue govuk-body-m"
+                      >
+                        Now
+                      </p>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -3932,17 +4009,21 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                   <div
                     className=""
                   >
-                    <input
-                      aria-describedby=""
-                      className="govuk-input govuk-date-input__input govuk-input--width-4"
-                      defaultValue="2300"
-                      disabled={false}
-                      id="publish-end-time-input"
-                      name="publishEndTime"
-                      onBlur={[Function]}
-                      placeholder="hhmm"
-                      type="text"
-                    />
+                    <div
+                      className=""
+                    >
+                      <input
+                        aria-describedby=""
+                        className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue="2300"
+                        disabled={false}
+                        id="publish-end-time-input"
+                        name="publishEndTime"
+                        onBlur={[Function]}
+                        placeholder="hhmm"
+                        type="text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
+++ b/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
@@ -908,7 +908,7 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                       />
                     </div>
                     <button
-                      className="mt-3 govuk-link h-5"
+                      className="mt-3 govuk-link h-6"
                       data-module="govuk-button"
                       onClick={[Function]}
                     >
@@ -2374,7 +2374,7 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                       />
                     </div>
                     <button
-                      className="mt-3 govuk-link h-5"
+                      className="mt-3 govuk-link h-6"
                       data-module="govuk-button"
                       onClick={[Function]}
                     >
@@ -3891,7 +3891,7 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                       />
                     </div>
                     <button
-                      className="mt-3 govuk-link h-5"
+                      className="mt-3 govuk-link h-6"
                       data-module="govuk-button"
                       onClick={[Function]}
                     >

--- a/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
+++ b/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
@@ -908,7 +908,7 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                       />
                     </div>
                     <button
-                      className="mt-3 govuk-link"
+                      className="mt-3 govuk-link h-5"
                       data-module="govuk-button"
                       onClick={[Function]}
                     >
@@ -2374,7 +2374,7 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                       />
                     </div>
                     <button
-                      className="mt-3 govuk-link"
+                      className="mt-3 govuk-link h-5"
                       data-module="govuk-button"
                       onClick={[Function]}
                     >
@@ -3891,7 +3891,7 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                       />
                     </div>
                     <button
-                      className="mt-3 govuk-link"
+                      className="mt-3 govuk-link h-5"
                       data-module="govuk-button"
                       onClick={[Function]}
                     >

--- a/site/pages/create-social-media-post/[disruptionId]/__snapshots__/create-social-media-post.test.tsx.snap
+++ b/site/pages/create-social-media-post/[disruptionId]/__snapshots__/create-social-media-post.test.tsx.snap
@@ -232,17 +232,21 @@ exports[`pages > CreateSocialMediaPost > should render correctly with inputs and
               <div
                 className=""
               >
-                <input
-                  aria-describedby="publish-time-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  defaultValue="1805"
-                  disabled={false}
-                  id="publish-time-input"
-                  name="publishTime"
-                  onBlur={[Function]}
-                  placeholder="hhmm"
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="publish-time-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    defaultValue="1805"
+                    disabled={false}
+                    id="publish-time-input"
+                    name="publishTime"
+                    onBlur={[Function]}
+                    placeholder="hhmm"
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -783,16 +787,20 @@ exports[`pages > CreateSocialMediaPost > should render correctly with no inputs 
               <div
                 className=""
               >
-                <input
-                  aria-describedby="publish-time-hint"
-                  className="govuk-input govuk-date-input__input govuk-input--width-4"
-                  disabled={false}
-                  id="publish-time-input"
-                  name="publishTime"
-                  onBlur={[Function]}
-                  placeholder="hhmm"
-                  type="text"
-                />
+                <div
+                  className=""
+                >
+                  <input
+                    aria-describedby="publish-time-hint"
+                    className="govuk-input govuk-date-input__input govuk-input--width-4"
+                    disabled={false}
+                    id="publish-time-input"
+                    name="publishTime"
+                    onBlur={[Function]}
+                    placeholder="hhmm"
+                    type="text"
+                  />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
To test:

Go to the create disruption page and then scroll to publication date and time
As per wireframes should be a 'Now' button click on it to see the current date and time