### PR TITLE
Added additional fields in siri xml for stops and networks type consequences

### DIFF
--- a/site/pages/api/__snapshots__/publish-edit.test.ts.snap
+++ b/site/pages/api/__snapshots__/publish-edit.test.ts.snap
@@ -16,6 +16,9 @@ exports[`publishEdit > should write the correct disruptions data to dynamoDB 1`]
                 "VehicleMode": "tram",
               },
             },
+            "Operators": {
+              "AllOperators": "",
+            },
           },
           "Blocking": {
             "JourneyPlanner": false,

--- a/site/pages/api/__snapshots__/publish.test.ts.snap
+++ b/site/pages/api/__snapshots__/publish.test.ts.snap
@@ -16,6 +16,9 @@ exports[`publish > should write the correct disruptions data to dynamoDB 1`] = `
                 "VehicleMode": "tram",
               },
             },
+            "Operators": {
+              "AllOperators": "",
+            },
           },
           "Blocking": {
             "JourneyPlanner": false,

--- a/site/pages/api/__snapshots__/reject.test.ts.snap
+++ b/site/pages/api/__snapshots__/reject.test.ts.snap
@@ -16,6 +16,9 @@ exports[`reject > should write the correct disruptions data to dynamoDB 1`] = `
                 "VehicleMode": "tram",
               },
             },
+            "Operators": {
+              "AllOperators": "",
+            },
           },
           "Blocking": {
             "JourneyPlanner": false,
@@ -147,6 +150,9 @@ exports[`reject > should write the correct disruptions data to dynamoDB 3`] = `
                 "AllLines": "",
                 "VehicleMode": "tram",
               },
+            },
+            "Operators": {
+              "AllOperators": "",
             },
           },
           "Blocking": {

--- a/site/testData/mockData.ts
+++ b/site/testData/mockData.ts
@@ -449,7 +449,10 @@ export const ptSituationElementWithMultipleConsequences = {
             {
                 Condition: "unknown",
                 Severity: "slight",
-                Affects: { Networks: { AffectedNetwork: { VehicleMode: "tram", AllLines: "" } } },
+                Affects: {
+                    Networks: { AffectedNetwork: { VehicleMode: "tram", AllLines: "" } },
+                    Operators: { AllOperators: "" },
+                },
                 Advice: { Details: "Some consequence description" },
                 Blocking: { JourneyPlanner: false },
             },

--- a/site/utils/siri.ts
+++ b/site/utils/siri.ts
@@ -127,7 +127,16 @@ export const getPtSituationElementFromDraft = (disruption: Disruption) => {
                           Severity: consequence.disruptionSeverity,
                           Affects: {
                               ...(consequence.consequenceType === "networkWide" ||
-                              consequence.consequenceType === "operatorWide"
+                              consequence.consequenceType === "stops"
+                                  ? {
+                                        Operators: {
+                                            AllOperators: "",
+                                        },
+                                    }
+                                  : {}),
+                              ...(consequence.consequenceType === "networkWide" ||
+                              consequence.consequenceType === "operatorWide" ||
+                              consequence.consequenceType === "stops"
                                   ? {
                                         Networks: {
                                             AffectedNetwork: {


### PR DESCRIPTION
Testing instructions

- Create new disruptions or edit existing disruptions with network wide and operator wide consequences. Publish this disruptions and view the Siri SX xml which should have the additional fields.