### PR TITLE
Changes to mirror publish date fields when validity fields are entered

### DIFF
--- a/site/components/ReviewConsequenceTable.tsx
+++ b/site/components/ReviewConsequenceTable.tsx
@@ -249,7 +249,7 @@ const ReviewConsequenceTable = ({
                 Delete consequence
             </button>
             <button
-                key={consequence.consequenceIndex}
+                key={`duplicate-${consequence.consequenceIndex}`}
                 className="govuk-button govuk-button--secondary mt-4 ml-4"
                 data-module="govuk-button"
                 formAction={`/api/duplicate-consequence?consequenceId=${consequence.consequenceIndex}&return=${

--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -392,7 +392,12 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                 <DateSelector<DisruptionInfo>
                                     display="Publication start date"
                                     hint={{ hidden: false, text: "Enter in format DD/MM/YYYY" }}
-                                    value={pageState.inputs.publishStartDate}
+                                    value={
+                                        pageState.inputs.publishStartDate ||
+                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                            ? pageState.inputs.publishStartDate
+                                            : validity.disruptionStartDate
+                                    }
                                     disabled={false}
                                     disablePast={false}
                                     inputName="publishStartDate"
@@ -409,7 +414,12 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                 <TimeSelector<DisruptionInfo>
                                     display="Publication start time"
                                     hint="Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm"
-                                    value={pageState.inputs.publishStartTime}
+                                    value={
+                                        pageState.inputs.publishStartTime ||
+                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                            ? pageState.inputs.publishStartTime
+                                            : validity.disruptionStartTime
+                                    }
                                     disabled={false}
                                     inputName="publishStartTime"
                                     stateUpdater={stateUpdater}
@@ -429,7 +439,12 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                 <DateSelector<DisruptionInfo>
                                     display="Publication end date"
                                     hint={{ hidden: true, text: "Enter in format DD/MM/YYYY" }}
-                                    value={pageState.inputs.publishEndDate}
+                                    value={
+                                        pageState.inputs.publishEndDate ||
+                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                            ? pageState.inputs.publishEndDate
+                                            : validity.disruptionEndDate
+                                    }
                                     disabled={validity.disruptionNoEndDateTime === "true"}
                                     disablePast={false}
                                     inputName="publishEndDate"
@@ -441,7 +456,12 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                             <div className="pl-5">
                                 <TimeSelector<DisruptionInfo>
                                     display="Publication end time"
-                                    value={pageState.inputs.publishEndTime}
+                                    value={
+                                        pageState.inputs.publishEndTime ||
+                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                            ? pageState.inputs.publishEndTime
+                                            : validity.disruptionEndTime
+                                    }
                                     disabled={validity.disruptionNoEndDateTime === "true"}
                                     inputName="publishEndTime"
                                     stateUpdater={stateUpdater}

--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -429,8 +429,11 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishStartTime}
                                     resetError={
+                                        (!pageState.inputs.publishStartTime &&
+                                            !!validity.disruptionStartTime &&
+                                            validity.disruptionRepeats === "doesntRepeat") ||
                                         pageState.inputs.publishStartTime ===
-                                        convertDateTimeToFormat(new Date(), "HHmm")
+                                            convertDateTimeToFormat(new Date(), "HHmm")
                                     }
                                     showNowButton={handleNow}
                                 />

--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -394,8 +394,7 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint={{ hidden: false, text: "Enter in format DD/MM/YYYY" }}
                                     value={
                                         pageState.inputs.publishStartDate ||
-                                        pageState.inputs.disruptionRepeats === "weekly" ||
-                                        pageState.inputs.disruptionRepeats === "daily"
+                                        validity.disruptionRepeats !== "doesntRepeat"
                                             ? pageState.inputs.publishStartDate
                                             : validity.disruptionStartDate
                                     }
@@ -406,8 +405,11 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishStartDate}
                                     resetError={
+                                        (!pageState.inputs.publishStartDate &&
+                                            !!validity.disruptionStartDate &&
+                                            validity.disruptionRepeats === "doesntRepeat") ||
                                         pageState.inputs.publishStartDate ===
-                                        convertDateTimeToFormat(new Date(), "DD/MM/YYYY")
+                                            convertDateTimeToFormat(new Date(), "DD/MM/YYYY")
                                     }
                                 />
                             </div>
@@ -417,8 +419,7 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint="Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm"
                                     value={
                                         pageState.inputs.publishStartTime ||
-                                        pageState.inputs.disruptionRepeats === "weekly" ||
-                                        pageState.inputs.disruptionRepeats === "daily"
+                                        validity.disruptionRepeats !== "doesntRepeat"
                                             ? pageState.inputs.publishStartTime
                                             : validity.disruptionStartTime
                                     }
@@ -442,9 +443,7 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     display="Publication end date"
                                     hint={{ hidden: true, text: "Enter in format DD/MM/YYYY" }}
                                     value={
-                                        pageState.inputs.publishEndDate ||
-                                        pageState.inputs.disruptionRepeats === "weekly" ||
-                                        pageState.inputs.disruptionRepeats === "daily"
+                                        pageState.inputs.publishEndDate || validity.disruptionRepeats !== "doesntRepeat"
                                             ? pageState.inputs.publishEndDate
                                             : validity.disruptionEndDate
                                     }
@@ -454,22 +453,13 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     stateUpdater={stateUpdater}
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishEndDate}
-                                    resetError={
-                                        !!pageState.inputs.publishEndDate ||
-                                        (!pageState.inputs.publishEndDate &&
-                                            !!validity.disruptionEndDate &&
-                                            (pageState.inputs.disruptionRepeats === "weekly" ||
-                                                pageState.inputs.disruptionRepeats === "daily"))
-                                    }
                                 />
                             </div>
                             <div className="pl-5">
                                 <TimeSelector<DisruptionInfo>
                                     display="Publication end time"
                                     value={
-                                        pageState.inputs.publishEndTime ||
-                                        pageState.inputs.disruptionRepeats === "weekly" ||
-                                        pageState.inputs.disruptionRepeats === "daily"
+                                        pageState.inputs.publishEndTime || validity.disruptionRepeats !== "doesntRepeat"
                                             ? pageState.inputs.publishEndTime
                                             : validity.disruptionEndTime
                                     }
@@ -478,13 +468,6 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     stateUpdater={stateUpdater}
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishEndTime}
-                                    resetError={
-                                        !!pageState.inputs.publishEndTime ||
-                                        (!pageState.inputs.publishEndTime &&
-                                            !!validity.disruptionEndTime &&
-                                            (pageState.inputs.disruptionRepeats === "weekly" ||
-                                                pageState.inputs.disruptionRepeats === "daily"))
-                                    }
                                 />
                             </div>
                         </div>

--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -394,7 +394,8 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint={{ hidden: false, text: "Enter in format DD/MM/YYYY" }}
                                     value={
                                         pageState.inputs.publishStartDate ||
-                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                        pageState.inputs.disruptionRepeats === "weekly" ||
+                                        pageState.inputs.disruptionRepeats === "daily"
                                             ? pageState.inputs.publishStartDate
                                             : validity.disruptionStartDate
                                     }
@@ -416,7 +417,8 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint="Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm"
                                     value={
                                         pageState.inputs.publishStartTime ||
-                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                        pageState.inputs.disruptionRepeats === "weekly" ||
+                                        pageState.inputs.disruptionRepeats === "daily"
                                             ? pageState.inputs.publishStartTime
                                             : validity.disruptionStartTime
                                     }
@@ -441,7 +443,8 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint={{ hidden: true, text: "Enter in format DD/MM/YYYY" }}
                                     value={
                                         pageState.inputs.publishEndDate ||
-                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                        pageState.inputs.disruptionRepeats === "weekly" ||
+                                        pageState.inputs.disruptionRepeats === "daily"
                                             ? pageState.inputs.publishEndDate
                                             : validity.disruptionEndDate
                                     }
@@ -451,6 +454,13 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     stateUpdater={stateUpdater}
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishEndDate}
+                                    resetError={
+                                        !!pageState.inputs.publishEndDate ||
+                                        (!pageState.inputs.publishEndDate &&
+                                            !!validity.disruptionEndDate &&
+                                            (pageState.inputs.disruptionRepeats === "weekly" ||
+                                                pageState.inputs.disruptionRepeats === "daily"))
+                                    }
                                 />
                             </div>
                             <div className="pl-5">
@@ -458,7 +468,8 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     display="Publication end time"
                                     value={
                                         pageState.inputs.publishEndTime ||
-                                        (pageState.inputs?.validity?.length && pageState.inputs?.validity?.length > 0)
+                                        pageState.inputs.disruptionRepeats === "weekly" ||
+                                        pageState.inputs.disruptionRepeats === "daily"
                                             ? pageState.inputs.publishEndTime
                                             : validity.disruptionEndTime
                                     }
@@ -467,6 +478,13 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     stateUpdater={stateUpdater}
                                     initialErrors={pageState.errors}
                                     schema={createDisruptionSchema.shape.publishEndTime}
+                                    resetError={
+                                        !!pageState.inputs.publishEndTime ||
+                                        (!pageState.inputs.publishEndTime &&
+                                            !!validity.disruptionEndTime &&
+                                            (pageState.inputs.disruptionRepeats === "weekly" ||
+                                                pageState.inputs.disruptionRepeats === "daily"))
+                                    }
                                 />
                             </div>
                         </div>

--- a/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
+++ b/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
@@ -2365,6 +2365,7 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                       <input
                         aria-describedby="publish-start-time-hint"
                         className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue=""
                         disabled={false}
                         id="publish-start-time-input"
                         name="publishStartTime"
@@ -2498,6 +2499,7 @@ exports[`pages > CreateDisruption > should render correctly with no inputs 1`] =
                       <input
                         aria-describedby=""
                         className="govuk-input govuk-date-input__input govuk-input--width-4"
+                        defaultValue=""
                         disabled={false}
                         id="publish-end-time-input"
                         name="publishEndTime"


### PR DESCRIPTION
Testing instructions

- Click create new disruption link and select validity date fields. This should update respective fields in publish disruption