### PR TITLE
fix: fixed duplicate display id issue

### DIFF
--- a/site/pages/api/duplicate-disruption.api.ts
+++ b/site/pages/api/duplicate-disruption.api.ts
@@ -1,4 +1,5 @@
 import { PublishStatus } from "@create-disruptions-data/shared-ts/enums";
+import cryptoRandomString from "crypto-random-string";
 import { NextApiRequest, NextApiResponse } from "next";
 import { randomUUID } from "crypto";
 import { REVIEW_DISRUPTION_PAGE_PATH } from "../../constants";
@@ -36,10 +37,12 @@ const duplicateDisruption = async (req: NextApiRequest, res: NextApiResponse): P
 
         const newDisruptionId = randomUUID();
 
+        const displayId = cryptoRandomString({ length: 6 });
         const draftDisruption: Disruption = {
             ...validatedDisruptionBody.data,
             publishStatus: PublishStatus.draft,
             disruptionId: newDisruptionId,
+            displayId,
             ...(disruptionToDuplicate.consequences
                 ? {
                       consequences: disruptionToDuplicate.consequences.map((c) => ({
@@ -63,7 +66,11 @@ const duplicateDisruption = async (req: NextApiRequest, res: NextApiResponse): P
         }
 
         await upsertDisruptionInfo(
-            { ...validatedDisruptionBody.data, disruptionId: newDisruptionId },
+            {
+                ...validatedDisruptionBody.data,
+                disruptionId: newDisruptionId,
+                displayId,
+            },
             session.orgId,
             session.isOrgStaff,
         );

--- a/site/pages/api/duplicate-disruption.test.ts
+++ b/site/pages/api/duplicate-disruption.test.ts
@@ -96,7 +96,7 @@ describe("duplicate-disruption API", () => {
             return newDefaultDisruptionId;
         });
         cryptoRandomStringSpy.mockImplementation(() => {
-            return "8fg3ha";
+            return "9fg4gc";
         });
     });
 
@@ -114,7 +114,7 @@ describe("duplicate-disruption API", () => {
             {
                 ...createDisruptionsSchemaRefined.parse(disruption),
                 disruptionId: newDefaultDisruptionId,
-                displayId: "8fg3ha",
+                displayId: "9fg4gc",
             },
             DEFAULT_ORG_ID,
             mockSession.isOrgStaff,

--- a/site/pages/api/duplicate-disruption.test.ts
+++ b/site/pages/api/duplicate-disruption.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment  */
 import { MiscellaneousReason, PublishStatus, Severity, VehicleMode } from "@create-disruptions-data/shared-ts/enums";
+import * as cryptoRandomString from "crypto-random-string";
 import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
 import * as crypto from "crypto";
 import duplicateDisruption from "./duplicate-disruption.api";
@@ -64,6 +65,10 @@ describe("duplicate-disruption API", () => {
         randomUUID: vi.fn(),
     }));
 
+    vi.mock("crypto-random-string", () => ({
+        default: vi.fn(),
+    }));
+
     const upsertConsequenceSpy = vi.spyOn(dynamo, "upsertConsequence");
     const upsertDisruptionInfoSpy = vi.spyOn(dynamo, "upsertDisruptionInfo");
     vi.mock("../../data/dynamo", () => ({
@@ -76,6 +81,7 @@ describe("duplicate-disruption API", () => {
         vi.resetAllMocks();
     });
 
+    const cryptoRandomStringSpy = vi.spyOn(cryptoRandomString, "default");
     const getSessionSpy = vi.spyOn(session, "getSession");
 
     const getDisruptionByIdSpy = vi.spyOn(dynamo, "getDisruptionById");
@@ -88,6 +94,9 @@ describe("duplicate-disruption API", () => {
         });
         randomUUIDSpy.mockImplementation(() => {
             return newDefaultDisruptionId;
+        });
+        cryptoRandomStringSpy.mockImplementation(() => {
+            return "8fg3ha";
         });
     });
 
@@ -105,6 +114,7 @@ describe("duplicate-disruption API", () => {
             {
                 ...createDisruptionsSchemaRefined.parse(disruption),
                 disruptionId: newDefaultDisruptionId,
+                displayId: "8fg3ha",
             },
             DEFAULT_ORG_ID,
             mockSession.isOrgStaff,

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -659,8 +659,7 @@ const DisruptionDetail = ({
                                 Delete disruption
                             </button>
                         )}
-                        {disruption.publishStatus !== PublishStatus.editing &&
-                        disruption.publishStatus !== PublishStatus.pendingAndEditing ? (
+                        {disruption.publishStatus === PublishStatus.published ? (
                             <button
                                 className="govuk-button govuk-button--secondary ml-5 mt-8"
                                 data-module="govuk-button"

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -1630,13 +1630,6 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
           >
             Delete disruption
           </button>
-          <button
-            className="govuk-button govuk-button--secondary ml-5 mt-8"
-            data-module="govuk-button"
-            onClick={[Function]}
-          >
-            Duplicate disruption
-          </button>
         </div>
       </form>
     </main>

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -9,7 +9,7 @@ import ErrorSummary from "../../components/ErrorSummary";
 import CsrfForm from "../../components/form/CsrfForm";
 import Table from "../../components/form/Table";
 import { BaseLayout } from "../../components/layout/Layout";
-import Popup from "../../components/Popup";
+
 import ReviewConsequenceTable, { createChangeLink } from "../../components/ReviewConsequenceTable";
 import {
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
@@ -44,9 +44,6 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
     const [popUpState, setPopUpState] = useState<{ name: string; hiddenInputs: { name: string; value: string }[] }>();
     const [socialMediaPostPopUpState, setSocialMediaPostPopUpState] = useState<{
         name: string;
-        hiddenInputs: { name: string; value: string }[];
-    }>();
-    const [duplicateDisruptionPopUpState, setDuplicateDisruptionPopUpState] = useState<{
         hiddenInputs: { name: string; value: string }[];
     }>();
 
@@ -189,10 +186,6 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
         setSocialMediaPostPopUpState(undefined);
     };
 
-    const cancelActionHandlerDuplicateDisruption = (): void => {
-        setDuplicateDisruptionPopUpState(undefined);
-    };
-
     useEffect(() => {
         if (window.GOVUKFrontend && !hasInitialised.current) {
             window.GOVUKFrontend.initAll();
@@ -284,17 +277,7 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
                     hiddenInputs={socialMediaPostPopUpState.hiddenInputs}
                 />
             ) : null}
-            {duplicateDisruptionPopUpState && csrfToken ? (
-                <Popup
-                    action={"/api/duplicate-disruption"}
-                    cancelActionHandler={cancelActionHandlerDuplicateDisruption}
-                    csrfToken={csrfToken}
-                    hiddenInputs={duplicateDisruptionPopUpState.hiddenInputs}
-                    continueText="Yes, duplicate"
-                    cancelText="No, return"
-                    questionText={"Are you sure you wish to duplicate the disruption?"}
-                />
-            ) : null}
+
             <CsrfForm action="/api/publish" method="post" csrfToken={csrfToken}>
                 <>
                     <ErrorSummary errors={errors} />
@@ -550,23 +533,6 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
                             }}
                         >
                             Delete disruption
-                        </button>
-                        <button
-                            className="govuk-button govuk-button--secondary ml-5 mt-8"
-                            data-module="govuk-button"
-                            onClick={(e) => {
-                                e.preventDefault();
-                                setDuplicateDisruptionPopUpState({
-                                    hiddenInputs: [
-                                        {
-                                            name: "disruptionId",
-                                            value: disruption.disruptionId,
-                                        },
-                                    ],
-                                });
-                            }}
-                        >
-                            Duplicate disruption
                         </button>
                         <Link
                             className="govuk-button mt-8 ml-5 govuk-button--secondary"

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -1599,13 +1599,6 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
           >
             Delete disruption
           </button>
-          <button
-            className="govuk-button govuk-button--secondary ml-5 mt-8"
-            data-module="govuk-button"
-            onClick={[Function]}
-          >
-            Duplicate disruption
-          </button>
           <a
             className="govuk-button mt-8 ml-5 govuk-button--secondary"
             data-module="govuk-button"


### PR DESCRIPTION
Duplicate a disruption - then check if the display ids are different
Duplicate disruption button should only be shown when published status