### PR TITLE
Fix to display tram services in drop down

### DIFF
--- a/shared-ts/enums.ts
+++ b/shared-ts/enums.ts
@@ -177,7 +177,17 @@ export enum SocialMediaPostStatus {
     rejected = "Rejected",
 }
 
-export enum Modes {
+export enum Datasource {
     tnds = "tnds",
     bods = "bods",
+}
+
+export enum Modes {
+    bus = "bus",
+    coach = "coach",
+    tram = "tram",
+    ferry = "ferry",
+    rail = "rail",
+    underground = "underground",
+    metro = "metro",
 }

--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -1,4 +1,4 @@
-import { Modes } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource } from "@create-disruptions-data/shared-ts/enums";
 import { Feature, GeoJsonProperties, Geometry } from "geojson";
 import { LineLayout, LinePaint, MapLayerMouseEvent } from "mapbox-gl";
 import {
@@ -32,7 +32,7 @@ import { flattenZodErrors } from "../../utils";
 import { getStopType, sortStops } from "../../utils/formUtils";
 
 interface ServiceMapProps extends MapProps {
-    dataSource?: Modes;
+    dataSource?: Datasource;
 }
 interface MapProps {
     initialViewState: Partial<ViewState>;

--- a/site/data/refDataApi.ts
+++ b/site/data/refDataApi.ts
@@ -1,4 +1,4 @@
-import { Modes } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource, Modes } from "@create-disruptions-data/shared-ts/enums";
 import { Position } from "geojson";
 import { z } from "zod";
 import { API_BASE_URL } from "../constants";
@@ -44,8 +44,8 @@ export const fetchStops = async (input: FetchStopsInput) => {
 
 interface FetchServicesInput {
     adminAreaCodes?: string[];
-    dataSource?: Modes;
-    modes?: string[];
+    dataSource?: Datasource;
+    modes?: Modes[];
 }
 
 export const fetchServices = async (input: FetchServicesInput) => {
@@ -81,7 +81,7 @@ export const fetchServices = async (input: FetchServicesInput) => {
 interface FetchServicesByStopsInput {
     atcoCodes?: string[];
     includeRoutes?: boolean;
-    dataSource?: Modes;
+    dataSource?: Datasource;
 }
 
 export const fetchServicesByStops = async (input: FetchServicesByStopsInput) => {
@@ -156,7 +156,7 @@ export const fetchServiceStops = async (input: FetchServiceStops) => {
 
 interface FetchOperatorsInput {
     adminAreaCodes: string[];
-    dataSource?: Modes;
+    dataSource?: Datasource;
 }
 
 export const fetchOperators = async (input: FetchOperatorsInput) => {

--- a/site/data/refDataApi.ts
+++ b/site/data/refDataApi.ts
@@ -45,6 +45,7 @@ export const fetchStops = async (input: FetchStopsInput) => {
 interface FetchServicesInput {
     adminAreaCodes?: string[];
     dataSource?: Modes;
+    modes?: string[];
 }
 
 export const fetchServices = async (input: FetchServicesInput) => {
@@ -58,6 +59,10 @@ export const fetchServices = async (input: FetchServicesInput) => {
 
     if (input.dataSource) {
         queryStringItems.push(`dataSource=${input.dataSource}`);
+    }
+
+    if (input.modes && input.modes.length > 0) {
+        queryStringItems.push(`modes=${input.modes.join(",")}`);
     }
 
     const res = await fetch(`${searchApiUrl}${queryStringItems.length > 0 ? `?${queryStringItems.join("&")}` : ""}`, {

--- a/site/interfaces/index.ts
+++ b/site/interfaces/index.ts
@@ -68,8 +68,6 @@ export interface PageState<T> {
 }
 
 export interface CreateConsequenceProps {
-    initialBodsServices?: Service[];
-    initialTndsServices?: Service[];
     initialStops?: Stop[];
     disruptionSummary?: string;
 }

--- a/site/interfaces/index.ts
+++ b/site/interfaces/index.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest } from "next";
 import { z } from "zod";
 import { ServerResponse } from "http";
-import { Service, Stop } from "../schemas/consequence.schema";
+import { Stop } from "../schemas/consequence.schema";
 import { Session, SessionWithOrgDetail } from "../schemas/session.schema";
 
 export interface ErrorInfo {

--- a/site/pages/account-settings.page.tsx
+++ b/site/pages/account-settings.page.tsx
@@ -1,4 +1,4 @@
-import { Modes } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { ReactElement, useState } from "react";
@@ -23,7 +23,7 @@ const AccountSettings = ({ sessionWithOrg, csrfToken }: AccountSettingsProps): R
     const [mode, setMode] = useState<ModeType>(sessionWithOrg.mode);
     const [errors, setErrors] = useState<ErrorInfo[]>([]);
 
-    const updateOrg = async (key: string, value: Modes) => {
+    const updateOrg = async (key: string, value: Datasource) => {
         const previousValue = mode[key as keyof ModeType];
         setMode({ ...mode, [key]: value });
         const url = new URL("/api/admin/update-org", window.location.origin);
@@ -125,7 +125,7 @@ const AccountSettings = ({ sessionWithOrg, csrfToken }: AccountSettingsProps): R
                         value="tnds"
                         checked={inputValue === "tnds"}
                         onChange={async () => {
-                            await updateOrg(name, Modes.tnds);
+                            await updateOrg(name, Datasource.tnds);
                         }}
                     />
                     <label key={`${name}-tnds`} htmlFor={`${name}-tnds`} className="govuk-label govuk-radios__label">
@@ -141,7 +141,7 @@ const AccountSettings = ({ sessionWithOrg, csrfToken }: AccountSettingsProps): R
                         value="bods"
                         checked={inputValue === "bods"}
                         onChange={async () => {
-                            await updateOrg(name, Modes.bods);
+                            await updateOrg(name, Datasource.bods);
                         }}
                     />
                     <label key={`${name}-bods`} htmlFor={`${name}-bods`} className="govuk-label govuk-radios__label">

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -1,4 +1,4 @@
-import { Modes, VehicleMode } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource, VehicleMode } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -53,7 +53,7 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
         queryParams["return"]?.includes(REVIEW_DISRUPTION_PAGE_PATH) ||
         queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH);
 
-    const [dataSource, setDataSource] = useState<Modes>(Modes.bods);
+    const [dataSource, setDataSource] = useState<Datasource>(Datasource.bods);
 
     useEffect(() => {
         const source = props.sessionWithOrg?.mode[pageState?.inputs?.vehicleMode as keyof ModeType];

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -83,6 +83,7 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
     const [stopsSearchInput, setStopsSearchInput] = useState<string>("");
     const [searched, setSearchedOptions] = useState<Partial<(Routes & { serviceId: number })[]>>([]);
     const [servicesRecords, setServicesRecords] = useState<Service[]>([]);
+    const [dataSource, setDataSource] = useState<Datasource>(Datasource.bods);
 
     useEffect(() => {
         const loadOptions = async () => {
@@ -270,7 +271,19 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
 
         if (source && pageState?.inputs?.vehicleMode) {
             fetchData(source, pageState.inputs.vehicleMode)
-                .then(() => ({}))
+                .then(() => {
+                    if (dataSource !== source) {
+                        setDataSource(source);
+                        setPageState({
+                            ...pageState,
+                            inputs: {
+                                ...pageState.inputs,
+                                services: [],
+                                stops: [],
+                            },
+                        });
+                    }
+                })
                 .catch(() => setServicesRecords([]));
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -1,4 +1,4 @@
-import { Modes } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource, Modes, VehicleMode } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -244,14 +244,14 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
         }
     }, [pageState?.inputs?.services]);
 
-    const fetchData = async (source: Modes, vehicleMode: string) => {
-        let mode: string[] = [];
-        if (vehicleMode === "ferryService") {
-            mode = ["ferry"];
-        } else if (vehicleMode === "tram") {
-            mode = ["tram", "metro"];
+    const fetchData = async (source: Datasource, vehicleMode: string) => {
+        let mode: Modes[] = [];
+        if (vehicleMode === VehicleMode.ferryService.toString()) {
+            mode = [Modes.ferry];
+        } else if (vehicleMode === VehicleMode.tram.toString()) {
+            mode = [Modes.tram, Modes.metro];
         } else {
-            mode = [vehicleMode];
+            mode = [vehicleMode as Modes];
         }
 
         const serviceData = await fetchServices({

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -1,4 +1,4 @@
-import { Modes, Progress, PublishStatus, Severity } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource, Progress, PublishStatus, Severity } from "@create-disruptions-data/shared-ts/enums";
 import { LoadingBox } from "@govuk-react/loading-box";
 import { pdf } from "@react-pdf/renderer";
 import { Dayjs } from "dayjs";
@@ -582,7 +582,7 @@ const ViewAllDisruptions = ({
         const [operators, servicesBodsData, servicesTndsData] = await Promise.all([
             fetchOperators({ adminAreaCodes: adminAreaCodes }),
             fetchServices({ adminAreaCodes: adminAreaCodes }),
-            fetchServices({ adminAreaCodes: adminAreaCodes, dataSource: Modes.tnds }),
+            fetchServices({ adminAreaCodes: adminAreaCodes, dataSource: Datasource.tnds }),
         ]);
 
         let services: Service[] = [];

--- a/site/schemas/organisation.schema.ts
+++ b/site/schemas/organisation.schema.ts
@@ -1,17 +1,22 @@
-import { Modes } from "@create-disruptions-data/shared-ts/enums";
+import { Datasource } from "@create-disruptions-data/shared-ts/enums";
 import { z } from "zod";
 import { setZodDefaultError } from "../utils";
 
 export const modeSchema = z.object({
-    bus: z.nativeEnum(Modes),
-    tram: z.nativeEnum(Modes),
-    ferryService: z.nativeEnum(Modes),
-    rail: z.nativeEnum(Modes),
+    bus: z.nativeEnum(Datasource),
+    tram: z.nativeEnum(Datasource),
+    ferryService: z.nativeEnum(Datasource),
+    rail: z.nativeEnum(Datasource),
 });
 
 export type ModeType = z.infer<typeof modeSchema>;
 
-export const defaultModes: ModeType = { bus: Modes.bods, tram: Modes.bods, ferryService: Modes.bods, rail: Modes.bods };
+export const defaultModes: ModeType = {
+    bus: Datasource.bods,
+    tram: Datasource.bods,
+    ferryService: Datasource.bods,
+    rail: Datasource.bods,
+};
 
 export const organisationSchema = z.object({
     name: z.string(setZodDefaultError("Enter an organisation name")).min(3),


### PR DESCRIPTION
Create service consequence page should now display tram services in drop down when vehicle mode is selected. This is extended to all other vehicle mode values.