### PR TITLE
pre-populate draft disruptions when click the link in dashboards page

### DIFF
--- a/site/pages/__snapshots__/dashboard.test.tsx.snap
+++ b/site/pages/__snapshots__/dashboard.test.tsx.snap
@@ -417,7 +417,7 @@ exports[`pages > dashboard > should render correctly when there are all three li
       </a>
       <a
         className="govuk-link"
-        href="/dashboard"
+        href="/view-all-disruptions?draft=true"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onTouchStart={[Function]}
@@ -898,7 +898,7 @@ exports[`pages > dashboard > should render correctly when there are no disruptio
       </a>
       <a
         className="govuk-link"
-        href="/dashboard"
+        href="/view-all-disruptions?draft=true"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onTouchStart={[Function]}
@@ -1516,7 +1516,7 @@ exports[`pages > dashboard > should render correctly when there are only live di
       </a>
       <a
         className="govuk-link"
-        href="/dashboard"
+        href="/view-all-disruptions?draft=true"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onTouchStart={[Function]}
@@ -2134,7 +2134,7 @@ exports[`pages > dashboard > should render correctly when there are only recentl
       </a>
       <a
         className="govuk-link"
-        href="/dashboard"
+        href="/view-all-disruptions?draft=true"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onTouchStart={[Function]}
@@ -2752,7 +2752,7 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
       </a>
       <a
         className="govuk-link"
-        href="/dashboard"
+        href="/view-all-disruptions?draft=true"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onTouchStart={[Function]}

--- a/site/pages/__snapshots__/view-all-disruptions.test.tsx.snap
+++ b/site/pages/__snapshots__/view-all-disruptions.test.tsx.snap
@@ -1,5 +1,914 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`pages > viewAllDisruptions > should render correctly when filter is set to draft status 1`] = `
+[
+  <div
+    className="app-phase-banner__wrapper"
+  >
+    <div
+      className="govuk-phase-banner max-w-[960px] w-[90%] border-0 mx-auto app-phase-banner app-width-container"
+    >
+      <p
+        className="govuk-phase-banner__content"
+      >
+        <strong
+          className="govuk-tag govuk-phase-banner__content__tag"
+        >
+          alpha
+        </strong>
+        <span
+          className="govuk-phase-banner__text"
+        >
+          This is a new service – your
+           
+          <a
+            className="govuk-link"
+            href="/feedback"
+            id="feedback-link"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+          >
+            feedback
+          </a>
+           
+          will help us to improve it.
+        </span>
+      </p>
+    </div>
+  </div>,
+  <div
+    className="govuk-width-container"
+  >
+    <main
+      className="govuk-main-wrapper"
+      id="main-content"
+    >
+      <h1
+        className="govuk-heading-xl"
+      >
+        View all disruptions
+      </h1>
+      <div>
+        <a
+          className="govuk-button govuk-button--start"
+          data-module="govuk-button"
+          draggable="false"
+          href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333"
+          id="create-new-button"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+        >
+          Create new disruption
+          <svg
+            className="govuk-button__start-icon"
+            focusable="false"
+            height="19"
+            role="presentation"
+            viewBox="0 0 33 40"
+            width="17.5"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0 0h13l20 20-20 20H0l20-20z"
+              fill="currentColor"
+            />
+          </svg>
+        </a>
+        <div
+          className="flex"
+        >
+          <button
+            className="govuk-button govuk-button--secondary block"
+            data-module="govuk-button"
+            onClick={[Function]}
+          >
+            Show 
+            filters
+          </button>
+          <button
+            className="govuk-button govuk-button--secondary ml-2"
+            data-module="govuk-button"
+            onClick={[Function]}
+          >
+            Export
+          </button>
+        </div>
+      </div>
+      <table
+        className="govuk-table"
+      >
+        <thead
+          className="govuk-table__head"
+        >
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              ID
+            </th>
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              Summary
+            </th>
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              Modes
+            </th>
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              Starts
+            </th>
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              Ends
+            </th>
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              Severity
+            </th>
+            <th
+              className="govuk-table__header align-middle"
+              scope="col"
+            >
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          className="govuk-table__body"
+        >
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/c58ba826-ac18-41c5-8476-8172dfa6ea24?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              05/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/e234615d-8301-49c2-8143-1fca9dc187db?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              18/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/type-of-consequence/dfd19560-99c1-4da6-8a73-de1220f37056/0?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Busted reunion traffic
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram, Ferry, Train
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              19/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              11/05/2024
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Draft
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/c58ba826-ac18-41c5-8476-8172dfa6ea24?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              05/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/e234615d-8301-49c2-8143-1fca9dc187db?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              18/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/type-of-consequence/dfd19560-99c1-4da6-8a73-de1220f37056/0?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Busted reunion traffic
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram, Ferry, Train
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              19/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              11/05/2024
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Draft
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/c58ba826-ac18-41c5-8476-8172dfa6ea24?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              05/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/e234615d-8301-49c2-8143-1fca9dc187db?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              18/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/type-of-consequence/dfd19560-99c1-4da6-8a73-de1220f37056/0?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Busted reunion traffic
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram, Ferry, Train
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              19/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              11/05/2024
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Draft
+            </td>
+          </tr>
+          <tr
+            className="govuk-table__row"
+          >
+            <th
+              className="govuk-table__header align-middle"
+              scope="row"
+            >
+              <a
+                className="govuk-link"
+                href="/disruption-detail/c58ba826-ac18-41c5-8476-8172dfa6ea24?return=%2Fview-all-disruptions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                8fg3ha
+              </a>
+            </th>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Tram
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              05/01/2022
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              No end time
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Very severe
+            </td>
+            <td
+              className="govuk-table__cell align-middle"
+            >
+              Open
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <nav
+        className="govuk-pagination"
+        role="navigation"
+      >
+        <ul
+          className="govuk-pagination__list"
+        >
+           
+          <li
+            className="govuk-pagination__item govuk-pagination__item--current"
+          >
+            <a
+              aria-label="Page 1"
+              className="govuk-link govuk-pagination__link"
+              data-module="govuk-button"
+              draggable="false"
+              href="#"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onTouchStart={[Function]}
+              role="button"
+            >
+              1
+               
+            </a>
+          </li>
+          <li
+            className="govuk-pagination__item"
+          >
+            <a
+              aria-label="Page 2"
+              className="govuk-link govuk-pagination__link"
+              data-module="govuk-button"
+              draggable="false"
+              href="#"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onTouchStart={[Function]}
+              role="button"
+            >
+              2
+               
+            </a>
+          </li>
+        </ul>
+        <div
+          className="govuk-pagination__next"
+        >
+          <a
+            aria-label="Page 2"
+            className="govuk-link govuk-pagination__link"
+            data-module="govuk-button"
+            draggable="false"
+            href=""
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+            rel="next"
+            role="button"
+          >
+            <span
+              className="govuk-pagination__link-title"
+            >
+              Next
+            </span>
+             
+            <svg
+              aria-hidden="true"
+              className="govuk-pagination__icon govuk-pagination__icon--next"
+              focusable="false"
+              height="13"
+              viewBox="0 0 15 13"
+              width="15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"
+              />
+            </svg>
+          </a>
+        </div>
+      </nav>
+    </main>
+    <div>
+      <h2
+        className="govuk-heading-s"
+      >
+        Help and Support
+      </h2>
+      <p
+        className="govuk-body"
+      >
+        If you are having problems, please contact the Create Disruption Service via this link:
+         
+        <a
+          className="govuk-link govuk-!-font-size-19"
+          href="/contact"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onTouchStart={[Function]}
+        >
+          Contact us
+        </a>
+      </p>
+    </div>
+  </div>,
+  <footer
+    className="govuk-footer"
+    role="contentinfo"
+  >
+    <div
+      className="govuk-width-container"
+    >
+      <div
+        className="govuk-footer__meta"
+      >
+        <div
+          className="govuk-footer__meta-item govuk-footer__meta-item--grow"
+        >
+          <h2
+            className="govuk-visually-hidden"
+          >
+            Support links
+          </h2>
+          <ul
+            className="govuk-footer__inline-list"
+          >
+            <li
+              className="govuk-footer__inline-list-item"
+            >
+              <a
+                className="govuk-footer__link"
+                href="/contact"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                Help
+              </a>
+            </li>
+            <li
+              className="govuk-footer__inline-list-item"
+            >
+              <a
+                className="govuk-footer__link"
+                href="/cookies"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                Cookies
+              </a>
+            </li>
+            <li
+              className="govuk-footer__inline-list-item"
+            >
+              <a
+                className="govuk-footer__link"
+                href="/contact"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                Contact
+              </a>
+            </li>
+            <li
+              className="govuk-footer__inline-list-item"
+            >
+              <a
+                className="govuk-footer__link"
+                href="/accessibility"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                Accessibility
+              </a>
+            </li>
+            <li
+              className="govuk-footer__inline-list-item"
+            >
+              <a
+                className="govuk-footer__link"
+                href="https://www.gov.uk/help/terms-conditions"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                Terms and conditions
+              </a>
+            </li>
+            <li
+              className="govuk-footer__inline-list-item"
+            >
+              <a
+                className="govuk-footer__link"
+                href="/privacy"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onTouchStart={[Function]}
+              >
+                Privacy
+              </a>
+            </li>
+          </ul>
+          <p
+            className="govuk-footer__body"
+          >
+            Built by the
+             
+            <a
+              className="govuk-footer__link"
+              href="https://www.gov.uk/government/organisations/department-for-transport"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onTouchStart={[Function]}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Department for Transport
+            </a>
+          </p>
+          <svg
+            aria-hidden="true"
+            className="govuk-footer__licence-logo"
+            focusable="false"
+            height="17"
+            viewBox="0 0 483.2 195.7"
+            width="41"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            className="govuk-footer__licence-description"
+          >
+            All content is available under the
+             
+            <a
+              className="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onTouchStart={[Function]}
+              rel="license"
+            >
+              Open Government Licence v3.0
+            </a>
+            , except where otherwise stated
+          </span>
+        </div>
+        <div
+          className="govuk-footer__meta-item"
+        >
+          <a
+            className="govuk-footer__link govuk-footer__copyright-logo bg-govuk-crest"
+            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+          >
+            © Crown copyright
+          </a>
+        </div>
+      </div>
+    </div>
+  </footer>,
+]
+`;
+
 exports[`pages > viewAllDisruptions > should render correctly when filter is set to pending approval status 1`] = `
 [
   <div

--- a/site/pages/dashboard.page.tsx
+++ b/site/pages/dashboard.page.tsx
@@ -251,7 +251,7 @@ const Dashboard = ({
                 <h2 className="govuk-heading-s text-govBlue">View all social media</h2>
             </Link>
 
-            <Link className="govuk-link" href="/dashboard">
+            <Link className="govuk-link" href="/view-all-disruptions?draft=true">
                 <h2 className="govuk-heading-s text-govBlue">Draft disruptions</h2>
             </Link>
         </BaseLayout>

--- a/site/pages/view-all-disruptions.page.tsx
+++ b/site/pages/view-all-disruptions.page.tsx
@@ -87,7 +87,7 @@ export interface ViewAllDisruptionsProps {
     disruptions: TableDisruption[];
     adminAreaCodes: string[];
     newDisruptionId: string;
-    showPending?: boolean;
+    filterStatus?: Progress;
 }
 
 export interface Filter {
@@ -357,7 +357,7 @@ const ViewAllDisruptions = ({
     disruptions,
     newDisruptionId,
     adminAreaCodes,
-    showPending = false,
+    filterStatus,
 }: ViewAllDisruptionsProps): ReactElement => {
     const [numberOfDisruptionsPages, setNumberOfDisruptionsPages] = useState<number>(
         Math.ceil(disruptions.length / 10),
@@ -373,7 +373,7 @@ const ViewAllDisruptions = ({
     const [filter, setFilter] = useState<Filter>({
         services: [],
         operators: [],
-        status: showPending ? Progress.pendingApproval : undefined,
+        status: filterStatus,
     });
     const [showFilters, setShowFilters] = useState(false);
     const [filtersLoading, setFiltersLoading] = useState(false);
@@ -1033,13 +1033,14 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         });
 
         const showPending = ctx.query.pending?.toString() === "true";
+        const showDraft = ctx.query.draft?.toString() === "true";
 
         return {
             props: {
                 disruptions: shortenedData,
                 adminAreaCodes: session.adminAreaCodes,
                 newDisruptionId: randomUUID(),
-                showPending,
+                filterStatus: showPending ? Progress.pendingApproval : showDraft ? Progress.draft : undefined,
             },
         };
     }

--- a/site/pages/view-all-disruptions.test.tsx
+++ b/site/pages/view-all-disruptions.test.tsx
@@ -133,6 +133,23 @@ describe("pages", () => {
                 .toJSON();
             expect(tree).toMatchSnapshot();
         });
+
+        it("should render correctly when filter is set to draft status", () => {
+            useRouter.mockImplementation(() => ({
+                query: { draft: true },
+            }));
+
+            const tree = renderer
+                .create(
+                    <ViewAllDisruptions
+                        disruptions={[...disruptions, ...disruptions, ...disruptions, ...disruptions]}
+                        newDisruptionId={defaultNewDisruptionId}
+                        adminAreaCodes={["099"]}
+                    />,
+                )
+                .toJSON();
+            expect(tree).toMatchSnapshot();
+        });
     });
 });
 


### PR DESCRIPTION
When view draft disruptions link is clicked from dashboards page then the view all disruptions page is displayed with draft disruption status field set