### PR TITLE
fix: Tooltip hover on unselected stop not working within polygon shape

### DIFF
--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -110,15 +110,12 @@ const Map = ({
 
     const handleMouseEnter = useCallback(
         (id: string) => {
-            const stopsOnMap = [
-                ...selected,
-                ...searched.filter((stop) => !markerData.map((marker) => marker.atcoCode).includes(stop.atcoCode)),
-            ];
+            const stopsOnMap = [...selected, ...searched];
             const stopInfo = stopsOnMap.find((stop) => stop.atcoCode === id);
 
             if (stopInfo) setPopupInfo(stopInfo);
         },
-        [searched, selected, markerData],
+        [searched, selected],
     );
 
     const unselectMarker = useCallback(

--- a/site/components/map/StopsMap.tsx
+++ b/site/components/map/StopsMap.tsx
@@ -50,14 +50,11 @@ const Map = ({
 
     const handleMouseEnter = useCallback(
         (id: string) => {
-            const stopsOnMap = [
-                ...selected,
-                ...searched.filter((stop) => !markerData.map((marker) => marker.atcoCode).includes(stop.atcoCode)),
-            ];
+            const stopsOnMap = [...selected, ...searched];
             const stopInfo = stopsOnMap.find((stop) => stop.atcoCode === id);
             if (stopInfo) setPopupInfo(stopInfo);
         },
-        [searched, selected, markerData],
+        [searched, selected],
     );
 
     const unselectMarker = useCallback(


### PR DESCRIPTION
To revert the changes done in https://github.com/Department-for-Transport-Disruptions/create-disruptions-data/pull/83/commits/4d59ee8cba8b7eed7d8798bee69e7fe4a113952a

To test it:

1.  Login and got to create / edit service consequences
2.  Click a mode e.g. Bus and then draw a polygon 
3.  Hover over a grey stop and it should have a tooltip
