### PR TITLE
Fix to remove limit on selecting stops after choosing services

### DIFF
--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -189,7 +189,7 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                 ],
             });
         } else {
-            if (stopToAdd && (pageState.inputs.stops ? pageState.inputs.stops.length < 100 : true)) {
+            if (stopToAdd) {
                 setPageState({
                     ...pageState,
                     inputs: {

--- a/site/schemas/consequence.schema.ts
+++ b/site/schemas/consequence.schema.ts
@@ -103,12 +103,7 @@ export type ServiceByStop = z.infer<typeof serviceByStopSchema>;
 export const servicesConsequenceSchema = z.object({
     ...baseConsequence,
     consequenceType: z.literal("services", setZodDefaultError("Select a consequence type")),
-    stops: z
-        .array(stopSchema)
-        .max(100, {
-            message: "Maximum of 100 stops permitted per consequence",
-        })
-        .optional(),
+    stops: z.array(stopSchema).optional(),
     services: z
         .array(serviceSchema)
         .min(1, {


### PR DESCRIPTION
Navigate to adding consequences of type services. Select a stop type and then a service which has more than 100 stops. Click select all which should select all the stops and not limit it to 100