### PR TITLE
fix: Splicing AtcoCodes to prevent infinite loading

### DIFF
--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -269,7 +269,7 @@ const Map = ({
         } else {
             if (showSelectAllText) {
                 setLoading(true);
-                const atcoCodes = includeMarkerData ? markerData.map((marker) => marker.atcoCode) : [];
+                const atcoCodes = includeMarkerData ? markerData.map((marker) => marker.atcoCode).splice(0, 100) : [];
 
                 const servicesInPolygon = includeMarkerData
                     ? dataSource


### PR DESCRIPTION
## Description

Polygon tool does not work in "services" consequence page map (watch video evidence)

## Testing Instructions

- Use codes 083, 107, 110, 146, 147
- Go to Manchester on the stops consequence page draw a similar sized polygon to the one in the bugfix ticket video
- Press back on the top left 
- Go to services consequence draw a similar polygon on the same area
- The loading icon should not stay there infinitely but it may take long to load the data about a minute or so

