### PR TITLE
fix: Services with stops show warning message

### DIFF
--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -206,10 +206,28 @@ const Map = ({
         }
     };
 
+    const selectStop = (id: string) => {
+        if (state) {
+            const stop: Stop[] = getSelectedStopsFromMapMarkers(searched, id);
+            stateUpdater({
+                ...state,
+                inputs: {
+                    ...state.inputs,
+                    stops: sortStops([...selected, ...stop]),
+                },
+                errors: state.errors,
+            });
+        }
+    };
+
     const selectMarker = useCallback(
         async (id: string) => {
             setLoading(true);
-            await addServiceFromSingleStop(id);
+            if (features && Object.values(features).length > 0) {
+                await addServiceFromSingleStop(id);
+            } else {
+                selectStop(id);
+            }
             setLoading(false);
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
When you go to the services consequence page and select services (with stops) and leave one in the dropdown - then click on a stop the warning shows. This is incorrect behaviour as the services with stops should allow you to select the stops and not show the warning message.

Logic has been fixed so only if there is a polygon does it check for services connected to the stop and show the warning if needed.