### PR TITLE
Fix to align change links column

### DIFF
--- a/site/components/ReviewConsequenceTable.tsx
+++ b/site/components/ReviewConsequenceTable.tsx
@@ -1,7 +1,7 @@
 import { Consequence, Disruption } from "@create-disruptions-data/shared-ts/disruptionTypes";
 import Link from "next/link";
 import { ReactElement, ReactNode } from "react";
-import Table from "./form/Table";
+import Table, { CellProps } from "./form/Table";
 import {
     CONSEQUENCE_TYPES,
     CREATE_CONSEQUENCE_NETWORK_PATH,
@@ -54,33 +54,45 @@ export const createChangeLink = (
 };
 
 const getRows = (consequence: Consequence, disruption: Disruption, isDisruptionDetail?: boolean) => {
-    const rows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[] = [
+    const rows: { header?: string | ReactNode; cells: CellProps[] }[] = [
         {
             header: "Consequence type",
             cells: [
-                getDisplayByValue(CONSEQUENCE_TYPES, consequence.consequenceType),
-                createChangeLink(
-                    "consequence-type",
-                    TYPE_OF_CONSEQUENCE_PAGE_PATH,
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: getDisplayByValue(CONSEQUENCE_TYPES, consequence.consequenceType),
+                    styles: {
+                        width: "w-1/2",
+                    },
+                },
+                {
+                    value: createChangeLink(
+                        "consequence-type",
+                        TYPE_OF_CONSEQUENCE_PAGE_PATH,
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                    styles: {
+                        width: "w-1/10",
+                    },
+                },
             ],
         },
         {
             header: "Mode of transport",
             cells: [
-                getDisplayByValue(VEHICLE_MODES, consequence.vehicleMode),
-                createChangeLink(
-                    "vehicle-mode",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                { value: getDisplayByValue(VEHICLE_MODES, consequence.vehicleMode) },
+                {
+                    value: createChangeLink(
+                        "vehicle-mode",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         },
     ];
@@ -89,20 +101,24 @@ const getRows = (consequence: Consequence, disruption: Disruption, isDisruptionD
         rows.push({
             header: "Service(s)",
             cells: [
-                consequence.services
-                    .map(
-                        (service) =>
-                            `${service.lineName} - ${service.origin} - ${service.destination} (${service.operatorShortName})`,
-                    )
-                    .join(", "),
-                createChangeLink(
-                    "service",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: consequence.services
+                        .map(
+                            (service) =>
+                                `${service.lineName} - ${service.origin} - ${service.destination} (${service.operatorShortName})`,
+                        )
+                        .join(", "),
+                },
+                {
+                    value: createChangeLink(
+                        "service",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         });
     }
@@ -111,23 +127,27 @@ const getRows = (consequence: Consequence, disruption: Disruption, isDisruptionD
         rows.push({
             header: "Stops affected",
             cells: [
-                consequence.stops
-                    ? consequence.stops
-                          .map((stop) =>
-                              stop.commonName && stop.indicator && stop.atcoCode
-                                  ? `${stop.commonName} ${stop.indicator} ${stop.atcoCode}`
-                                  : `${stop.commonName} ${stop.atcoCode}`,
-                          )
-                          .join(", ")
-                    : "N/A",
-                createChangeLink(
-                    "stops-affected",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: consequence.stops
+                        ? consequence.stops
+                              .map((stop) =>
+                                  stop.commonName && stop.indicator && stop.atcoCode
+                                      ? `${stop.commonName} ${stop.indicator} ${stop.atcoCode}`
+                                      : `${stop.commonName} ${stop.atcoCode}`,
+                              )
+                              .join(", ")
+                        : "N/A",
+                },
+                {
+                    value: createChangeLink(
+                        "stops-affected",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         });
     }
@@ -136,17 +156,21 @@ const getRows = (consequence: Consequence, disruption: Disruption, isDisruptionD
         rows.push({
             header: "Operators affected",
             cells: [
-                consequence.consequenceOperators
-                    ? consequence.consequenceOperators.map((op) => op.operatorNoc).join(", ")
-                    : "N/A",
-                createChangeLink(
-                    "operators-affected",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: consequence.consequenceOperators
+                        ? consequence.consequenceOperators.map((op) => op.operatorNoc).join(", ")
+                        : "N/A",
+                },
+                {
+                    value: createChangeLink(
+                        "operators-affected",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         });
     }
@@ -155,43 +179,55 @@ const getRows = (consequence: Consequence, disruption: Disruption, isDisruptionD
         {
             header: "Advice to display",
             cells: [
-                consequence.description,
-                createChangeLink(
-                    "advice-to-display",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: consequence.description,
+                },
+                {
+                    value: createChangeLink(
+                        "advice-to-display",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         },
         {
             header: "Remove from journey planner",
             cells: [
-                splitCamelCaseToString(consequence.removeFromJourneyPlanners),
-                createChangeLink(
-                    "remove-from-journey-planners",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: splitCamelCaseToString(consequence.removeFromJourneyPlanners),
+                },
+                {
+                    value: createChangeLink(
+                        "remove-from-journey-planners",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         },
         {
             header: "Disruption delay",
             cells: [
-                consequence.disruptionDelay ? `${consequence.disruptionDelay} minutes` : "N/A",
-                createChangeLink(
-                    "disruption-delay",
-                    getConsequenceUrl(consequence.consequenceType),
-                    disruption,
-                    consequence.consequenceIndex,
-                    true,
-                    isDisruptionDetail,
-                ),
+                {
+                    value: consequence.disruptionDelay ? `${consequence.disruptionDelay} minutes` : "N/A",
+                },
+                {
+                    value: createChangeLink(
+                        "disruption-delay",
+                        getConsequenceUrl(consequence.consequenceType),
+                        disruption,
+                        consequence.consequenceIndex,
+                        true,
+                        isDisruptionDetail,
+                    ),
+                },
             ],
         },
     );

--- a/site/components/__snapshots__/ReviewConsequenceTable.test.tsx.snap
+++ b/site/components/__snapshots__/ReviewConsequenceTable.test.tsx.snap
@@ -53,12 +53,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Mode of transport
         </th>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           Bus
         </td>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           <a
             className="govuk-link"
@@ -81,12 +81,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Advice to display
         </th>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           The road is closed for the following reasons: Example, example, example, example
         </td>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           <a
             className="govuk-link"
@@ -109,12 +109,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Remove from journey planner
         </th>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           Yes
         </td>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           <a
             className="govuk-link"
@@ -137,12 +137,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Disruption delay
         </th>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           33 minutes
         </td>
         <td
-          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
         >
           <a
             className="govuk-link"

--- a/site/components/__snapshots__/ReviewConsequenceTable.test.tsx.snap
+++ b/site/components/__snapshots__/ReviewConsequenceTable.test.tsx.snap
@@ -25,12 +25,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Consequence type
         </th>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
         >
           Network wide
         </td>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
         >
           <a
             className="govuk-link"
@@ -53,12 +53,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Mode of transport
         </th>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           Bus
         </td>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           <a
             className="govuk-link"
@@ -81,12 +81,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Advice to display
         </th>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           The road is closed for the following reasons: Example, example, example, example
         </td>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           <a
             className="govuk-link"
@@ -109,12 +109,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Remove from journey planner
         </th>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           Yes
         </td>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           <a
             className="govuk-link"
@@ -137,12 +137,12 @@ exports[`ReviewConsequenceTable > should render the table with data 1`] = `
           Disruption delay
         </th>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           33 minutes
         </td>
         <td
-          className="govuk-table__cell align-middle"
+          className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
         >
           <a
             className="govuk-link"

--- a/site/components/form/Table.tsx
+++ b/site/components/form/Table.tsx
@@ -15,8 +15,12 @@ interface TableProps {
     rows: { header?: string | ReactNode; cells: string[] | ReactNode[] | CellProps[] }[];
 }
 
-const isCellProps = (cell: any): cell is CellProps => {
-    return cell && (typeof cell.value === "string" || typeof cell.value === "object");
+const isCellProps = (cell: string | ReactNode | CellProps): cell is CellProps => {
+    if (cell && typeof cell === "object" && "value" in cell) {
+        return true;
+    } else {
+        return false;
+    }
 };
 
 const Table = ({ caption, columns = [], rows }: TableProps): ReactElement => {
@@ -49,7 +53,7 @@ const Table = ({ caption, columns = [], rows }: TableProps): ReactElement => {
                         {row.cells.map((cell, i) => (
                             <td
                                 className={`govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl ${
-                                    isCellProps(cell) ? cell.styles?.width : ""
+                                    isCellProps(cell) && cell.styles?.width ? cell.styles?.width : ""
                                 }`}
                                 key={i}
                             >

--- a/site/components/form/Table.tsx
+++ b/site/components/form/Table.tsx
@@ -1,10 +1,23 @@
 import { ReactElement, ReactNode } from "react";
 
+export interface TableStyles {
+    width?: string;
+}
+
+export interface CellProps {
+    value: string | ReactNode;
+    styles?: TableStyles;
+}
+
 interface TableProps {
     caption?: { text: string; size: "s" | "m" | "l" };
     columns?: string[];
-    rows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[];
+    rows: { header?: string | ReactNode; cells: string[] | ReactNode[] | CellProps[] }[];
 }
+
+const isCellProps = (cell: any): cell is CellProps => {
+    return cell && (typeof cell.value === "string" || typeof cell.value === "object");
+};
 
 const Table = ({ caption, columns = [], rows }: TableProps): ReactElement => {
     return (
@@ -34,8 +47,13 @@ const Table = ({ caption, columns = [], rows }: TableProps): ReactElement => {
                             </th>
                         )}
                         {row.cells.map((cell, i) => (
-                            <td className="govuk-table__cell align-middle" key={i}>
-                                {cell}
+                            <td
+                                className={`govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl ${
+                                    isCellProps(cell) ? cell.styles?.width : ""
+                                }`}
+                                key={i}
+                            >
+                                {isCellProps(cell) ? cell.value : cell}
                             </td>
                         ))}
                     </tr>

--- a/site/components/form/Table.tsx
+++ b/site/components/form/Table.tsx
@@ -36,7 +36,7 @@ const Table = ({ caption, columns = [], rows }: TableProps): ReactElement => {
             <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
                     {columns.map((column) => (
-                        <th scope="col" className="govuk-table__header align-middle" key={column}>
+                        <th scope="col" className="govuk-table__header align-middle px-2" key={column}>
                             {column}
                         </th>
                     ))}

--- a/site/components/form/__snapshots__/SearchSelect.test.tsx.snap
+++ b/site/components/form/__snapshots__/SearchSelect.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`SearchSelect > should render correctly with errors 1`] = `
             test row 1
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             1
           </td>
@@ -163,7 +163,7 @@ exports[`SearchSelect > should render correctly with errors 1`] = `
             test row 2
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             2
           </td>
@@ -311,7 +311,7 @@ exports[`SearchSelect > should render correctly with no errors 1`] = `
             test row 1
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             1
           </td>
@@ -326,7 +326,7 @@ exports[`SearchSelect > should render correctly with no errors 1`] = `
             test row 2
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             2
           </td>

--- a/site/components/form/__snapshots__/Table.test.tsx.snap
+++ b/site/components/form/__snapshots__/Table.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Table > should render correctly 1`] = `
         test row 1
       </th>
       <td
-        className="govuk-table__cell align-middle"
+        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
       >
         1
       </td>
@@ -57,7 +57,7 @@ exports[`Table > should render correctly 1`] = `
         test row 2
       </th>
       <td
-        className="govuk-table__cell align-middle"
+        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
       >
         2
       </td>
@@ -108,7 +108,7 @@ exports[`Table > should render correctly with jsx element 1`] = `
         test row 1
       </th>
       <td
-        className="govuk-table__cell align-middle"
+        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
       >
         <p>
           test 1
@@ -125,7 +125,7 @@ exports[`Table > should render correctly with jsx element 1`] = `
         test row 2
       </th>
       <td
-        className="govuk-table__cell align-middle"
+        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
       >
         2
       </td>
@@ -170,7 +170,7 @@ exports[`Table > should render correctly without a header 1`] = `
       className="govuk-table__row"
     >
       <td
-        className="govuk-table__cell align-middle"
+        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
       >
         1
       </td>
@@ -179,7 +179,7 @@ exports[`Table > should render correctly without a header 1`] = `
       className="govuk-table__row"
     >
       <td
-        className="govuk-table__cell align-middle"
+        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
       >
         2
       </td>

--- a/site/components/form/__snapshots__/Table.test.tsx.snap
+++ b/site/components/form/__snapshots__/Table.test.tsx.snap
@@ -16,13 +16,13 @@ exports[`Table > should render correctly 1`] = `
       className="govuk-table__row"
     >
       <th
-        className="govuk-table__header align-middle"
+        className="govuk-table__header align-middle px-2"
         scope="col"
       >
         test col 1
       </th>
       <th
-        className="govuk-table__header align-middle"
+        className="govuk-table__header align-middle px-2"
         scope="col"
       >
         test col 2
@@ -82,13 +82,13 @@ exports[`Table > should render correctly with jsx element 1`] = `
       className="govuk-table__row"
     >
       <th
-        className="govuk-table__header align-middle"
+        className="govuk-table__header align-middle px-2"
         scope="col"
       >
         test col 1
       </th>
       <th
-        className="govuk-table__header align-middle"
+        className="govuk-table__header align-middle px-2"
         scope="col"
       >
         test col 2
@@ -150,13 +150,13 @@ exports[`Table > should render correctly without a header 1`] = `
       className="govuk-table__row"
     >
       <th
-        className="govuk-table__header align-middle"
+        className="govuk-table__header align-middle px-2"
         scope="col"
       >
         test col 1
       </th>
       <th
-        className="govuk-table__header align-middle"
+        className="govuk-table__header align-middle px-2"
         scope="col"
       >
         test col 2

--- a/site/components/layout/__snapshots__/Tabs.test.tsx.snap
+++ b/site/components/layout/__snapshots__/Tabs.test.tsx.snap
@@ -93,12 +93,12 @@ exports[`Tabs > should render correctly when given a table as the content 1`] = 
             </a>
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             Test summary
           </td>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             01/01/2023 onwards
           </td>
@@ -121,12 +121,12 @@ exports[`Tabs > should render correctly when given a table as the content 1`] = 
             </a>
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             Test summary
           </td>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             02/01/2023 - 02/02-2024
           </td>
@@ -193,12 +193,12 @@ exports[`Tabs > should render correctly when given a table as the content 1`] = 
             </a>
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             Test summary
           </td>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             01/01/2023 onwards
           </td>
@@ -221,12 +221,12 @@ exports[`Tabs > should render correctly when given a table as the content 1`] = 
             </a>
           </th>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             Test summary
           </td>
           <td
-            className="govuk-table__cell align-middle"
+            className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
           >
             02/01/2023 - 02/02-2024
           </td>

--- a/site/components/layout/__snapshots__/Tabs.test.tsx.snap
+++ b/site/components/layout/__snapshots__/Tabs.test.tsx.snap
@@ -53,19 +53,19 @@ exports[`Tabs > should render correctly when given a table as the content 1`] = 
           className="govuk-table__row"
         >
           <th
-            className="govuk-table__header align-middle"
+            className="govuk-table__header align-middle px-2"
             scope="col"
           >
             ID
           </th>
           <th
-            className="govuk-table__header align-middle"
+            className="govuk-table__header align-middle px-2"
             scope="col"
           >
             Summary
           </th>
           <th
-            className="govuk-table__header align-middle"
+            className="govuk-table__header align-middle px-2"
             scope="col"
           >
             Affected dates
@@ -153,19 +153,19 @@ exports[`Tabs > should render correctly when given a table as the content 1`] = 
           className="govuk-table__row"
         >
           <th
-            className="govuk-table__header align-middle"
+            className="govuk-table__header align-middle px-2"
             scope="col"
           >
             ID
           </th>
           <th
-            className="govuk-table__header align-middle"
+            className="govuk-table__header align-middle px-2"
             scope="col"
           >
             Summary
           </th>
           <th
-            className="govuk-table__header align-middle"
+            className="govuk-table__header align-middle px-2"
             scope="col"
           >
             Affected dates

--- a/site/pages/__snapshots__/account-settings.test.tsx.snap
+++ b/site/pages/__snapshots__/account-settings.test.tsx.snap
@@ -86,12 +86,12 @@ exports[`accountSettings > should render correctly 1`] = `
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     test@example.com
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
                 <tr
@@ -104,7 +104,7 @@ exports[`accountSettings > should render correctly 1`] = `
                     Password
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     <input
                       className="bg-white"
@@ -116,7 +116,7 @@ exports[`accountSettings > should render correctly 1`] = `
                     />
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     <a
                       className="govuk-link"
@@ -139,12 +139,12 @@ exports[`accountSettings > should render correctly 1`] = `
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Test Org
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
                 <tr
@@ -157,10 +157,10 @@ exports[`accountSettings > should render correctly 1`] = `
                     NaPTAN Adminarea
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -199,7 +199,7 @@ exports[`accountSettings > should render correctly 1`] = `
                         Bus
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <div
                           className="govuk-radios govuk-radios--inline"
@@ -256,7 +256,7 @@ exports[`accountSettings > should render correctly 1`] = `
                         Tram
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <div
                           className="govuk-radios govuk-radios--inline"
@@ -313,7 +313,7 @@ exports[`accountSettings > should render correctly 1`] = `
                         Ferry
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <div
                           className="govuk-radios govuk-radios--inline"
@@ -370,7 +370,7 @@ exports[`accountSettings > should render correctly 1`] = `
                         Rail
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <div
                           className="govuk-radios govuk-radios--inline"

--- a/site/pages/__snapshots__/change-password.test.tsx.snap
+++ b/site/pages/__snapshots__/change-password.test.tsx.snap
@@ -390,7 +390,7 @@ exports[`changePassword > should render correctly when there are no inputs 1`] =
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
                 <tr
@@ -403,7 +403,7 @@ exports[`changePassword > should render correctly when there are no inputs 1`] =
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -793,7 +793,7 @@ exports[`changePassword > should render correctly with inputs and no errors 1`] 
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     test@example.com
                   </td>
@@ -808,7 +808,7 @@ exports[`changePassword > should render correctly with inputs and no errors 1`] 
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Test Org
                   </td>
@@ -1232,7 +1232,7 @@ exports[`changePassword > should render correctly with inputs and with errors 1`
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     test@example.com
                   </td>
@@ -1247,7 +1247,7 @@ exports[`changePassword > should render correctly with inputs and with errors 1`
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Test Org
                   </td>

--- a/site/pages/__snapshots__/dashboard.test.tsx.snap
+++ b/site/pages/__snapshots__/dashboard.test.tsx.snap
@@ -179,12 +179,12 @@ exports[`pages > dashboard > should render correctly when there are all three li
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A bad disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -257,12 +257,12 @@ exports[`pages > dashboard > should render correctly when there are all three li
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A more ok disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -291,12 +291,12 @@ exports[`pages > dashboard > should render correctly when there are all three li
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -369,12 +369,12 @@ exports[`pages > dashboard > should render correctly when there are all three li
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -1280,12 +1280,12 @@ exports[`pages > dashboard > should render correctly when there are only live di
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A bad disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -1314,12 +1314,12 @@ exports[`pages > dashboard > should render correctly when there are only live di
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A more ok disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -1348,12 +1348,12 @@ exports[`pages > dashboard > should render correctly when there are only live di
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -1382,12 +1382,12 @@ exports[`pages > dashboard > should render correctly when there are only live di
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -1984,12 +1984,12 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A bad disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2018,12 +2018,12 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A more ok disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2052,12 +2052,12 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2086,12 +2086,12 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2559,12 +2559,12 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A bad disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2593,12 +2593,12 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   A more ok disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2627,12 +2627,12 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"
@@ -2661,12 +2661,12 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                   </a>
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Another disruption
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <div
                     className="pb-2 last:pb-0"

--- a/site/pages/__snapshots__/dashboard.test.tsx.snap
+++ b/site/pages/__snapshots__/dashboard.test.tsx.snap
@@ -139,19 +139,19 @@ exports[`pages > dashboard > should render correctly when there are all three li
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -217,19 +217,19 @@ exports[`pages > dashboard > should render correctly when there are all three li
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -329,19 +329,19 @@ exports[`pages > dashboard > should render correctly when there are all three li
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -759,19 +759,19 @@ exports[`pages > dashboard > should render correctly when there are no disruptio
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -802,19 +802,19 @@ exports[`pages > dashboard > should render correctly when there are no disruptio
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -845,19 +845,19 @@ exports[`pages > dashboard > should render correctly when there are no disruptio
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -1240,19 +1240,19 @@ exports[`pages > dashboard > should render correctly when there are only live di
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -1420,19 +1420,19 @@ exports[`pages > dashboard > should render correctly when there are only live di
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -1463,19 +1463,19 @@ exports[`pages > dashboard > should render correctly when there are only live di
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -1858,19 +1858,19 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -1901,19 +1901,19 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -1944,19 +1944,19 @@ exports[`pages > dashboard > should render correctly when there are only recentl
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -2476,19 +2476,19 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -2519,19 +2519,19 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates
@@ -2699,19 +2699,19 @@ exports[`pages > dashboard > should render correctly when there are only upcomin
                 className="govuk-table__row"
               >
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   ID
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Summary
                 </th>
                 <th
-                  className="govuk-table__header align-middle"
+                  className="govuk-table__header align-middle px-2"
                   scope="col"
                 >
                   Affected dates

--- a/site/pages/__snapshots__/register.test.tsx.snap
+++ b/site/pages/__snapshots__/register.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`register > should render correctly when there are no inputs 1`] = `
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -452,7 +452,7 @@ exports[`register > should render correctly with inputs and no errors 1`] = `
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     dummyUser@gmail.com
                   </td>
@@ -467,7 +467,7 @@ exports[`register > should render correctly with inputs and no errors 1`] = `
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Test Org
                   </td>
@@ -867,7 +867,7 @@ exports[`register > should render correctly with inputs and with errors 1`] = `
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     dummyUser@gmail.com
                   </td>
@@ -882,7 +882,7 @@ exports[`register > should render correctly with inputs and with errors 1`] = `
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Test Org
                   </td>

--- a/site/pages/__snapshots__/reset-password.test.tsx.snap
+++ b/site/pages/__snapshots__/reset-password.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`reset-password > should render correctly when password is changed succe
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     dummyUser@gmail.com
                   </td>
@@ -483,7 +483,7 @@ exports[`reset-password > should render correctly when there are no inputs 1`] =
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -844,7 +844,7 @@ exports[`reset-password > should render correctly with inputs and no errors 1`] 
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     dummyUser@gmail.com
                   </td>
@@ -1240,7 +1240,7 @@ exports[`reset-password > should render correctly with inputs and with errors 1`
                     Email address
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     dummyUser@gmail.com
                   </td>

--- a/site/pages/__snapshots__/view-all-disruptions.test.tsx.snap
+++ b/site/pages/__snapshots__/view-all-disruptions.test.tsx.snap
@@ -171,32 +171,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -219,32 +219,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -267,32 +267,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -315,32 +315,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -363,32 +363,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -411,32 +411,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -459,32 +459,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -507,32 +507,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -555,32 +555,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -603,32 +603,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1080,32 +1080,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1128,32 +1128,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1176,32 +1176,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -1224,32 +1224,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1272,32 +1272,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1320,32 +1320,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -1368,32 +1368,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1416,32 +1416,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1464,32 +1464,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -1512,32 +1512,32 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -1989,32 +1989,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2037,32 +2037,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2085,32 +2085,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -2480,32 +2480,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2528,32 +2528,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2576,32 +2576,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -2624,32 +2624,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2672,32 +2672,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2720,32 +2720,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -2768,32 +2768,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2816,32 +2816,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               18/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>
@@ -2864,32 +2864,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Busted reunion traffic
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram, Ferry, Train
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               19/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               11/05/2024
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Draft
             </td>
@@ -2912,32 +2912,32 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
               </a>
             </th>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Alien attack - counter attack needed immediately to conserve human life. Aliens are known to be...
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Tram
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               05/01/2022
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               No end time
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Very severe
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Open
             </td>

--- a/site/pages/__snapshots__/view-all-disruptions.test.tsx.snap
+++ b/site/pages/__snapshots__/view-all-disruptions.test.tsx.snap
@@ -107,43 +107,43 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               ID
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Summary
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Modes
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Starts
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Ends
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Severity
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status
@@ -1016,43 +1016,43 @@ exports[`pages > viewAllDisruptions > should render correctly when filter is set
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               ID
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Summary
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Modes
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Starts
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Ends
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Severity
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status
@@ -1925,43 +1925,43 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               ID
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Summary
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Modes
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Starts
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Ends
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Severity
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status
@@ -2416,43 +2416,43 @@ exports[`pages > viewAllDisruptions > should render correctly when there are eno
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               ID
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Summary
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Modes
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Starts
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Ends
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Severity
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status
@@ -3325,43 +3325,43 @@ exports[`pages > viewAllDisruptions > should render correctly when there are no 
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               ID
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Summary
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Modes
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Starts
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Ends
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Severity
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status

--- a/site/pages/__snapshots__/view-all-social-media.test.tsx.snap
+++ b/site/pages/__snapshots__/view-all-social-media.test.tsx.snap
@@ -375,7 +375,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Message to appear
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     a post
                   </td>
@@ -390,7 +390,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Image
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     No image uploaded
                   </td>
@@ -405,7 +405,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish date
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     28/06/2023
                   </td>
@@ -420,7 +420,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish time
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     1700
                   </td>
@@ -435,7 +435,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Account name
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     25858639
                   </td>
@@ -450,7 +450,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     HootSuite profile
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     138196022
                   </td>
@@ -465,12 +465,12 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Status
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Successful
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -522,7 +522,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Message to appear
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     test 12345
                   </td>
@@ -537,7 +537,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Image
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     <a
                       className="govuk-link text-govBlue"
@@ -560,7 +560,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish date
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     28/06/2023
                   </td>
@@ -575,7 +575,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish time
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     1800
                   </td>
@@ -590,7 +590,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Account name
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     25858639
                   </td>
@@ -605,7 +605,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     HootSuite profile
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     138196022
                   </td>
@@ -620,12 +620,12 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Status
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Successful
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -677,7 +677,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Message to appear
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     oh no
                   </td>
@@ -692,7 +692,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Image
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     <a
                       className="govuk-link text-govBlue"
@@ -715,7 +715,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish date
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     04/07/2023
                   </td>
@@ -730,7 +730,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish time
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     1900
                   </td>
@@ -745,7 +745,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Account name
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     25858639
                   </td>
@@ -760,7 +760,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     HootSuite profile
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     138196022
                   </td>
@@ -775,12 +775,12 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Status
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Successful
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -832,7 +832,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Message to appear
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     a post
                   </td>
@@ -847,7 +847,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Image
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     No image uploaded
                   </td>
@@ -862,7 +862,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish date
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     28/06/2023
                   </td>
@@ -877,7 +877,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish time
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     1700
                   </td>
@@ -892,7 +892,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Account name
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     25858639
                   </td>
@@ -907,7 +907,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     HootSuite profile
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     138196022
                   </td>
@@ -922,12 +922,12 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Status
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Successful
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -979,7 +979,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Message to appear
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     another one here
                   </td>
@@ -994,7 +994,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Image
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     No image uploaded
                   </td>
@@ -1009,7 +1009,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish date
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     28/06/2023
                   </td>
@@ -1024,7 +1024,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Publish time
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     1715
                   </td>
@@ -1039,7 +1039,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Account name
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     25858639
                   </td>
@@ -1054,7 +1054,7 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     HootSuite profile
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     138196022
                   </td>
@@ -1069,12 +1069,12 @@ exports[`pages > viewAllSocialMedia > should render correctly when social media 
                     Status
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   >
                     Successful
                   </td>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>

--- a/site/pages/admin/__snapshots__/add-user.test.tsx.snap
+++ b/site/pages/admin/__snapshots__/add-user.test.tsx.snap
@@ -168,10 +168,10 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>
@@ -648,10 +648,10 @@ exports[`addUser > should render correctly with inputs 1`] = `
                     Organisation
                   </th>
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                   <td
-                    className="govuk-table__cell align-middle"
+                    className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                   />
                 </tr>
               </tbody>

--- a/site/pages/admin/__snapshots__/social-media-accounts.test.tsx.snap
+++ b/site/pages/admin/__snapshots__/social-media-accounts.test.tsx.snap
@@ -59,37 +59,37 @@ exports[`socialMediaAccounts > should render correctly when there are no inputs 
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Account type
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Username/page
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Added by
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Expires in
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Hootsuite Profiles
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Actions
@@ -361,37 +361,37 @@ exports[`socialMediaAccounts > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Account type
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Username/page
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Added by
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Expires in
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Hootsuite Profiles
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Actions

--- a/site/pages/admin/__snapshots__/social-media-accounts.test.tsx.snap
+++ b/site/pages/admin/__snapshots__/social-media-accounts.test.tsx.snap
@@ -405,35 +405,35 @@ exports[`socialMediaAccounts > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <p>
                 Hootsuite
               </p>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <p>
                 testemail@gmail.com
               </p>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <p>
                 Test Account
               </p>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <p>
                 Never
               </p>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <li
                 className="list-none"
@@ -463,7 +463,7 @@ exports[`socialMediaAccounts > should render correctly with inputs 1`] = `
               </li>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <button
                 className="govuk-link text-govBlue"

--- a/site/pages/admin/__snapshots__/user-management.test.tsx.snap
+++ b/site/pages/admin/__snapshots__/user-management.test.tsx.snap
@@ -399,22 +399,22 @@ exports[`userManagement > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Admin
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               dummy.user@gmail.com
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               Active
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <button
                 className="govuk-link"

--- a/site/pages/admin/__snapshots__/user-management.test.tsx.snap
+++ b/site/pages/admin/__snapshots__/user-management.test.tsx.snap
@@ -68,25 +68,25 @@ exports[`userManagement > should render correctly when there are no inputs 1`] =
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Account type
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               User email
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Action
@@ -367,25 +367,25 @@ exports[`userManagement > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Account type
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               User email
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Status
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Action

--- a/site/pages/create-consequence-network/__snapshots__/create-consequence-network.test.tsx.snap
+++ b/site/pages/create-consequence-network/__snapshots__/create-consequence-network.test.tsx.snap
@@ -84,12 +84,12 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with inputs 
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Network wide
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -669,12 +669,12 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with no inpu
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Network wide
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -1262,12 +1262,12 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with query p
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Network wide
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"

--- a/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
+++ b/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
@@ -84,12 +84,12 @@ exports[`pages > CreateConsequenceOperator > should render correctly with inputs
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Operator wide
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -292,15 +292,15 @@ exports[`pages > CreateConsequenceOperator > should render correctly with inputs
                 className="govuk-table__row"
               >
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 />
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   FMAN
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <button
                     className="govuk-link"
@@ -829,12 +829,12 @@ exports[`pages > CreateConsequenceOperator > should render correctly with no inp
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Operator wide
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -1544,12 +1544,12 @@ exports[`pages > CreateConsequenceOperator > should render correctly with query 
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Operator wide
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -1752,15 +1752,15 @@ exports[`pages > CreateConsequenceOperator > should render correctly with query 
                 className="govuk-table__row"
               >
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 />
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   FMAN
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <button
                     className="govuk-link"

--- a/site/pages/create-consequence-services/__snapshots__/create-consequence-services.test.tsx.snap
+++ b/site/pages/create-consequence-services/__snapshots__/create-consequence-services.test.tsx.snap
@@ -120,12 +120,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with errors
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Services
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -331,12 +331,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with errors
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       1 - Jordanthorpe - HigH Green (First South Yorkshire)
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -492,12 +492,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with errors
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T3 0100BRP90310
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -512,12 +512,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with errors
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T7 0100BRP90311
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -1176,12 +1176,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with inputs
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Services
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -1387,12 +1387,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with inputs
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       1 - Jordanthorpe - HigH Green (First South Yorkshire)
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -1548,12 +1548,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with inputs
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T3 0100BRP90310
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -1568,12 +1568,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with inputs
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T7 0100BRP90311
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -2200,12 +2200,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with no inp
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Services
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -3155,12 +3155,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with query 
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Services
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -3366,12 +3366,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with query 
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       1 - Jordanthorpe - HigH Green (First South Yorkshire)
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -3527,12 +3527,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with query 
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T3 0100BRP90310
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -3547,12 +3547,12 @@ exports[`pages > CreateConsequenceServices > should render correctly with query 
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T7 0100BRP90311
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"

--- a/site/pages/create-consequence-stops/__snapshots__/create-consequence-stops.test.tsx.snap
+++ b/site/pages/create-consequence-stops/__snapshots__/create-consequence-stops.test.tsx.snap
@@ -120,12 +120,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with errors an
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Stops
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -325,12 +325,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with errors an
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T3 0100BRP90310
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -345,12 +345,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with errors an
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T7 0100BRP90311
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -919,12 +919,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with inputs 1`
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Stops
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -1124,12 +1124,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with inputs 1`
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T3 0100BRP90310
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -1144,12 +1144,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with inputs 1`
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T7 0100BRP90311
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -1686,12 +1686,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with no inputs
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Stops
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2410,12 +2410,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with query par
                   Consequence type
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Stops
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2615,12 +2615,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with query par
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T3 0100BRP90310
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"
@@ -2635,12 +2635,12 @@ exports[`pages > CreateConsequenceStops > should render correctly with query par
                     className="govuk-table__row"
                   >
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       Temple Meads Stn T7 0100BRP90311
                     </td>
                     <td
-                      className="govuk-table__cell align-middle"
+                      className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                     >
                       <button
                         className="govuk-link"

--- a/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
+++ b/site/pages/create-disruption/__snapshots__/create-disruption.test.tsx.snap
@@ -424,12 +424,12 @@ exports[`pages > CreateDisruption > should render correctly with inputs 1`] = `
                   Validity period 1
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   01/04/2023 0100 - 03/04/2023 0200
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <button
                     className="govuk-link"
@@ -3426,12 +3426,12 @@ exports[`pages > CreateDisruption > should render correctly with query params 1`
                   Validity period 1
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   01/04/2023 0100 - 03/04/2023 0200
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <button
                     className="govuk-link"

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -7,7 +7,7 @@ import { parseCookies } from "nookies";
 import { ReactElement, ReactNode, useEffect, useRef, useState } from "react";
 import CsrfForm from "../../components/form/CsrfForm";
 import ErrorSummary from "../../components/form/ErrorSummary";
-import Table from "../../components/form/Table";
+import Table, { CellProps } from "../../components/form/Table";
 import { BaseLayout } from "../../components/layout/Layout";
 import DeleteConfirmationPopup from "../../components/popup/DeleteConfirmationPopup";
 import Popup from "../../components/popup/Popup";
@@ -80,112 +80,146 @@ const DisruptionDetail = ({
     const getSocialMediaRows = (post: SocialMediaPostTransformed) => {
         const isPendingOrRejected =
             post.status === SocialMediaPostStatus.pending || post.status === SocialMediaPostStatus.rejected;
-        const socialMediaTableRows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[] = [
+        const socialMediaTableRows: { header?: string | ReactNode; cells: CellProps[] }[] = [
             {
                 header: "Message to appear",
                 cells: [
-                    post.messageContent,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "message-to-appear",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.messageContent,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "message-to-appear",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                                  true,
+                              )
+                            : "",
+                        styles: {
+                            width: "w-1/10",
+                        },
+                    },
                 ],
             },
             {
                 header: "Image",
                 cells: [
-                    post.image ? (
-                        <Link className="govuk-link text-govBlue" key={post.image.key} href={post.image?.url ?? ""}>
-                            {post.image.originalFilename}
-                        </Link>
-                    ) : (
-                        "No image uploaded"
-                    ),
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "hootsuite-profile",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.image ? (
+                            <Link className="govuk-link text-govBlue" key={post.image.key} href={post.image?.url ?? ""}>
+                                {post.image.originalFilename}
+                            </Link>
+                        ) : (
+                            "No image uploaded"
+                        ),
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "hootsuite-profile",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Publish date",
                 cells: [
-                    post.publishDate,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "publish-date",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.publishDate,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "publish-date",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Publish time",
                 cells: [
-                    post.publishTime,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "publish-time",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.publishTime,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "publish-time",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Account name",
                 cells: [
-                    post.socialAccount,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "account-to-publish",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.socialAccount,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "account-to-publish",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "HootSuite profile",
                 cells: [
-                    post.hootsuiteProfile,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "hootsuite-profile",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.hootsuiteProfile,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "hootsuite-profile",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Status",
-                cells: [post.status, ""],
+                cells: [
+                    {
+                        value: post.status,
+                    },
+                    {
+                        value: "",
+                    },
+                ],
             },
         ];
 
@@ -342,134 +376,181 @@ const DisruptionDetail = ({
                             rows={[
                                 {
                                     header: "ID",
-                                    cells: [disruption.displayId, ""],
+                                    cells: [
+                                        {
+                                            value: disruption.displayId,
+                                        },
+                                        {
+                                            value: "",
+                                        },
+                                    ],
                                 },
                                 {
                                     header: "Type of disruption",
                                     cells: [
-                                        startCase(disruption.disruptionType),
-                                        createChangeLink(
-                                            "type-of-disruption",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: startCase(disruption.disruptionType),
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "type-of-disruption",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                            styles: {
+                                                width: "w-1/10",
+                                            },
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Summary",
                                     cells: [
-                                        disruption.summary,
-                                        createChangeLink(
-                                            "summary",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.summary,
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "summary",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Description",
                                     cells: [
-                                        disruption.description,
-                                        createChangeLink(
-                                            "description",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.description,
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "description",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Associated link",
                                     cells: [
-                                        disruption.associatedLink || "N/A",
-                                        createChangeLink(
-                                            "associated-link",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.associatedLink || "N/A",
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "associated-link",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Reason for disruption",
                                     cells: [
-                                        splitCamelCaseToString(disruption.disruptionReason),
-                                        createChangeLink(
-                                            "disruption-reason",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: splitCamelCaseToString(disruption.disruptionReason),
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "disruption-reason",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 ...getValidityRows(),
                                 {
                                     header: "Publish start date",
                                     cells: [
-                                        disruption.publishStartDate,
-                                        createChangeLink(
-                                            "publish-start-date",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.publishStartDate,
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-start-date",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Publish start time",
                                     cells: [
-                                        formatTime(disruption.publishStartTime),
-                                        createChangeLink(
-                                            "publish-start-time",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: formatTime(disruption.publishStartTime),
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-start-time",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Publish end date",
                                     cells: [
-                                        disruption.publishEndDate || "N/A",
-                                        createChangeLink(
-                                            "publish-end-date",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.publishEndDate || "N/A",
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-end-date",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Publish end time",
                                     cells: [
-                                        disruption.publishEndTime ? formatTime(disruption.publishEndTime) : "N/A",
-                                        ,
-                                        createChangeLink(
-                                            "publish-end-time",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.publishEndTime
+                                                ? formatTime(disruption.publishEndTime)
+                                                : "N/A",
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-end-time",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                             ]}

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -98,12 +98,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 />
               </tr>
               <tr
@@ -116,12 +116,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Planned
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                 >
                   <a
                     className="govuk-link"
@@ -144,12 +144,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -172,12 +172,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -200,12 +200,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -228,12 +228,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -256,7 +256,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Validity period 1
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     13/01/2022
@@ -270,7 +270,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -293,7 +293,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Validity period 2
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     15/01/2022
@@ -307,7 +307,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -330,12 +330,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -358,12 +358,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -386,12 +386,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -414,12 +414,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -489,12 +489,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Network wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -517,12 +517,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -545,12 +545,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -573,12 +573,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -601,12 +601,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -682,12 +682,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Operator wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -710,12 +710,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -738,12 +738,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -766,12 +766,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -794,12 +794,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -822,12 +822,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -903,12 +903,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Services
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -931,12 +931,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -959,12 +959,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -987,12 +987,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1015,12 +1015,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1043,12 +1043,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1071,12 +1071,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1174,12 +1174,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -1202,12 +1202,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1230,12 +1230,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1258,12 +1258,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1286,12 +1286,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1314,12 +1314,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1342,12 +1342,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>
@@ -1406,12 +1406,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -1434,7 +1434,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -1447,7 +1447,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1470,12 +1470,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1498,12 +1498,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1526,12 +1526,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1554,12 +1554,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1582,12 +1582,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>
@@ -1940,12 +1940,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 />
               </tr>
               <tr
@@ -1958,12 +1958,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Planned
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                 >
                   <a
                     className="govuk-link"
@@ -1986,12 +1986,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2014,12 +2014,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2042,12 +2042,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2070,12 +2070,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2098,7 +2098,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Validity period 1
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     13/01/2022
@@ -2112,7 +2112,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2135,7 +2135,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Validity period 2
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     15/01/2022
@@ -2149,7 +2149,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2172,12 +2172,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2200,12 +2200,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2228,12 +2228,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2256,12 +2256,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2331,12 +2331,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Network wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -2359,12 +2359,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2387,12 +2387,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2415,12 +2415,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2443,12 +2443,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2524,12 +2524,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Operator wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -2552,12 +2552,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2580,12 +2580,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2608,12 +2608,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2636,12 +2636,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2664,12 +2664,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2745,12 +2745,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Services
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -2773,12 +2773,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2801,12 +2801,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2829,12 +2829,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2857,12 +2857,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2885,12 +2885,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2913,12 +2913,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3016,12 +3016,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -3044,12 +3044,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3072,12 +3072,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3100,12 +3100,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3128,12 +3128,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3156,12 +3156,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3184,12 +3184,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>
@@ -3248,12 +3248,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -3276,7 +3276,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -3289,7 +3289,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3312,12 +3312,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3340,12 +3340,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3368,12 +3368,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3396,12 +3396,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3424,12 +3424,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -98,12 +98,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 />
               </tr>
               <tr
@@ -116,7 +116,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Planned
                 </td>
@@ -144,12 +144,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -172,12 +172,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -200,12 +200,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -228,12 +228,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -330,12 +330,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -358,12 +358,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -386,12 +386,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -414,12 +414,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -517,12 +517,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -545,12 +545,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -573,12 +573,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -601,12 +601,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -710,12 +710,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -738,12 +738,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -766,12 +766,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -794,12 +794,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -822,12 +822,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -931,12 +931,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -959,12 +959,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -987,12 +987,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1015,12 +1015,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1043,12 +1043,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1071,12 +1071,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1174,7 +1174,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -1202,12 +1202,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1230,12 +1230,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1258,12 +1258,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1286,12 +1286,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1314,12 +1314,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1342,12 +1342,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>
@@ -1406,7 +1406,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -1434,7 +1434,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -1447,7 +1447,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1470,12 +1470,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1498,12 +1498,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1526,12 +1526,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1554,12 +1554,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1582,12 +1582,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>
@@ -1940,12 +1940,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 />
               </tr>
               <tr
@@ -1958,7 +1958,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Planned
                 </td>
@@ -1986,12 +1986,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2014,12 +2014,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2042,12 +2042,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2070,12 +2070,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2172,12 +2172,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2200,12 +2200,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2228,12 +2228,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2256,12 +2256,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2359,12 +2359,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2387,12 +2387,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2415,12 +2415,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2443,12 +2443,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2552,12 +2552,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2580,12 +2580,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2608,12 +2608,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2636,12 +2636,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2664,12 +2664,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2773,12 +2773,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2801,12 +2801,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2829,12 +2829,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2857,12 +2857,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2885,12 +2885,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2913,12 +2913,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3016,7 +3016,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -3044,12 +3044,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3072,12 +3072,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3100,12 +3100,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3128,12 +3128,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3156,12 +3156,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3184,12 +3184,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>
@@ -3248,7 +3248,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -3276,7 +3276,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -3289,7 +3289,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3312,12 +3312,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3340,12 +3340,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3368,12 +3368,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3396,12 +3396,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3424,12 +3424,12 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and stat
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>

--- a/site/pages/disruption-history/__snapshots__/disruption-history.test.tsx.snap
+++ b/site/pages/disruption-history/__snapshots__/disruption-history.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`pages > DisruptionHistory > should render correctly 1`] = `
             className="govuk-table__row"
           >
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <h2
                 className="govuk-heading-s mb-3"
@@ -95,7 +95,7 @@ exports[`pages > DisruptionHistory > should render correctly 1`] = `
               </p>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <p
                 className="text-right"
@@ -108,7 +108,7 @@ exports[`pages > DisruptionHistory > should render correctly 1`] = `
             className="govuk-table__row"
           >
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <h2
                 className="govuk-heading-s mb-3"
@@ -132,7 +132,7 @@ exports[`pages > DisruptionHistory > should render correctly 1`] = `
               </p>
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <p
                 className="text-right"

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -8,7 +8,7 @@ import { parseCookies } from "nookies";
 import { ReactElement, ReactNode, useEffect, useRef, useState } from "react";
 import CsrfForm from "../../components/form/CsrfForm";
 import ErrorSummary from "../../components/form/ErrorSummary";
-import Table from "../../components/form/Table";
+import Table, { CellProps } from "../../components/form/Table";
 import { BaseLayout } from "../../components/layout/Layout";
 import NotificationBanner from "../../components/layout/NotificationBanner";
 import DeleteConfirmationPopup from "../../components/popup/DeleteConfirmationPopup";
@@ -54,106 +54,140 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
     const getSocialMediaRows = (post: SocialMediaPostTransformed) => {
         const isPendingOrRejected =
             post.status === SocialMediaPostStatus.pending || post.status === SocialMediaPostStatus.rejected;
-        const socialMediaTableRows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[] = [
+        const socialMediaTableRows: { header?: string | ReactNode; cells: CellProps[] }[] = [
             {
                 header: "Message to appear",
                 cells: [
-                    post.messageContent,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "message-to-appear",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.messageContent,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "message-to-appear",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                              )
+                            : "",
+                        styles: {
+                            width: "w-1/10",
+                        },
+                    },
                 ],
             },
             {
                 header: "Image",
                 cells: [
-                    post.image ? (
-                        <Link className="govuk-link text-govBlue" key={post.image.key} href={post.image?.url ?? ""}>
-                            {post.image.originalFilename}
-                        </Link>
-                    ) : (
-                        "No image uploaded"
-                    ),
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "hootsuite-profile",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.image ? (
+                            <Link className="govuk-link text-govBlue" key={post.image.key} href={post.image?.url ?? ""}>
+                                {post.image.originalFilename}
+                            </Link>
+                        ) : (
+                            "No image uploaded"
+                        ),
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "hootsuite-profile",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Publish date",
                 cells: [
-                    post.publishDate,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "publish-date",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.publishDate,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "publish-date",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Publish time",
                 cells: [
-                    post.publishTime,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "publish-time",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.publishTime,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "publish-time",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Account name",
                 cells: [
-                    post.socialAccount,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "account-to-publish",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.socialAccount,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "account-to-publish",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "HootSuite profile",
                 cells: [
-                    post.hootsuiteProfile,
-                    isPendingOrRejected
-                        ? createChangeLink(
-                              "hootsuite-profile",
-                              CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                              disruption,
-                              post.socialMediaPostIndex,
-                              true,
-                          )
-                        : "",
+                    {
+                        value: post.hootsuiteProfile,
+                    },
+                    {
+                        value: isPendingOrRejected
+                            ? createChangeLink(
+                                  "hootsuite-profile",
+                                  CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
+                                  disruption,
+                                  post.socialMediaPostIndex,
+                                  true,
+                              )
+                            : "",
+                    },
                 ],
             },
             {
                 header: "Status",
-                cells: [post.status, ""],
+                cells: [
+                    {
+                        value: post.status,
+                    },
+                    {
+                        value: "",
+                    },
+                ],
             },
         ];
 
@@ -294,119 +328,172 @@ const ReviewDisruption = ({ disruption, csrfToken, errors, canPublish }: ReviewD
                             rows={[
                                 {
                                     header: "ID",
-                                    cells: [disruption.displayId, ""],
+                                    cells: [
+                                        {
+                                            value: disruption.displayId,
+                                        },
+                                        {
+                                            value: "",
+                                        },
+                                    ],
                                 },
                                 {
                                     header: "Type of disruption",
                                     cells: [
-                                        startCase(disruption.disruptionType),
-                                        createChangeLink(
-                                            "type-of-disruption",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: startCase(disruption.disruptionType),
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "type-of-disruption",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                            styles: {
+                                                width: "w-1/10",
+                                            },
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Summary",
                                     cells: [
-                                        disruption.summary,
-                                        createChangeLink("summary", "/create-disruption", disruption, undefined, true),
+                                        {
+                                            value: disruption.summary,
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "summary",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Description",
                                     cells: [
-                                        disruption.description,
-                                        createChangeLink(
-                                            "description",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.description,
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "description",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Associated link",
                                     cells: [
-                                        disruption.associatedLink || "N/A",
-                                        createChangeLink(
-                                            "associated-link",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.associatedLink || "N/A",
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "associated-link",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Reason for disruption",
                                     cells: [
-                                        splitCamelCaseToString(disruption.disruptionReason),
-                                        createChangeLink(
-                                            "disruption-reason",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: splitCamelCaseToString(disruption.disruptionReason),
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "disruption-reason",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 ...getValidityRows(),
                                 {
                                     header: "Publish start date",
                                     cells: [
-                                        disruption.publishStartDate,
-                                        createChangeLink(
-                                            "publish-start-date",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.publishStartDate,
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-start-date",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Publish start time",
                                     cells: [
-                                        formatTime(disruption.publishStartTime),
-                                        createChangeLink(
-                                            "publish-start-time",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: formatTime(disruption.publishStartTime),
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-start-time",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Publish end date",
                                     cells: [
-                                        disruption.publishEndDate || "N/A",
-                                        createChangeLink(
-                                            "publish-end-date",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.publishEndDate || "N/A",
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-end-date",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                                 {
                                     header: "Publish end time",
                                     cells: [
-                                        disruption.publishEndTime ? formatTime(disruption.publishEndTime) : "N/A",
-                                        ,
-                                        createChangeLink(
-                                            "publish-end-time",
-                                            "/create-disruption",
-                                            disruption,
-                                            undefined,
-                                            true,
-                                        ),
+                                        {
+                                            value: disruption.publishEndTime
+                                                ? formatTime(disruption.publishEndTime)
+                                                : "N/A",
+                                        },
+                                        {
+                                            value: createChangeLink(
+                                                "publish-end-time",
+                                                "/create-disruption",
+                                                disruption,
+                                                undefined,
+                                                true,
+                                            ),
+                                        },
                                     ],
                                 },
                             ]}

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -110,12 +110,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 />
               </tr>
               <tr
@@ -128,7 +128,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Planned
                 </td>
@@ -156,12 +156,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -184,12 +184,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -212,12 +212,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -240,12 +240,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -342,12 +342,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -370,12 +370,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -398,12 +398,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -426,12 +426,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -529,12 +529,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -557,12 +557,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -585,12 +585,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -613,12 +613,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -722,12 +722,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -750,12 +750,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -778,12 +778,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -806,12 +806,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -834,12 +834,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -943,12 +943,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -971,12 +971,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -999,12 +999,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1027,12 +1027,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1055,12 +1055,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1083,12 +1083,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1186,7 +1186,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -1214,12 +1214,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1242,12 +1242,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1270,12 +1270,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1298,12 +1298,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1326,12 +1326,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1354,12 +1354,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>
@@ -1418,7 +1418,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -1446,7 +1446,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -1459,7 +1459,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1482,12 +1482,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1510,12 +1510,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1538,12 +1538,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1566,12 +1566,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -1594,12 +1594,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>
@@ -1931,12 +1931,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 />
               </tr>
               <tr
@@ -1949,7 +1949,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Planned
                 </td>
@@ -1977,12 +1977,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2005,12 +2005,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2033,12 +2033,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2061,12 +2061,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2163,12 +2163,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2191,12 +2191,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2219,12 +2219,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2247,12 +2247,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2350,12 +2350,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2378,12 +2378,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2406,12 +2406,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2434,12 +2434,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2543,12 +2543,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2571,12 +2571,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2599,12 +2599,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2627,12 +2627,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2655,12 +2655,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2764,12 +2764,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2792,12 +2792,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2820,12 +2820,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2848,12 +2848,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2876,12 +2876,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -2904,12 +2904,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3007,7 +3007,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -3035,12 +3035,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3063,12 +3063,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3091,12 +3091,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3119,12 +3119,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3147,12 +3147,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3175,12 +3175,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>
@@ -3239,7 +3239,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Test post 12345
                       </td>
@@ -3267,7 +3267,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -3280,7 +3280,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3303,12 +3303,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3331,12 +3331,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3359,12 +3359,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3387,12 +3387,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <a
                           className="govuk-link"
@@ -3415,12 +3415,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       />
                     </tr>
                   </tbody>

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -110,12 +110,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 />
               </tr>
               <tr
@@ -128,12 +128,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Planned
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                 >
                   <a
                     className="govuk-link"
@@ -156,12 +156,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -184,12 +184,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -212,12 +212,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -240,12 +240,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -268,7 +268,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Validity period 1
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     13/01/2022
@@ -282,7 +282,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -305,7 +305,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Validity period 2
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     15/01/2022
@@ -319,7 +319,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -342,12 +342,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -370,12 +370,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -398,12 +398,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -426,12 +426,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -501,12 +501,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Network wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -529,12 +529,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -557,12 +557,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -585,12 +585,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -613,12 +613,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -694,12 +694,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Operator wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -722,12 +722,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -750,12 +750,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -778,12 +778,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -806,12 +806,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -834,12 +834,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -915,12 +915,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Services
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -943,12 +943,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -971,12 +971,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -999,12 +999,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1027,12 +1027,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1055,12 +1055,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1083,12 +1083,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1186,12 +1186,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -1214,12 +1214,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1242,12 +1242,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1270,12 +1270,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1298,12 +1298,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1326,12 +1326,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1354,12 +1354,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>
@@ -1418,12 +1418,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -1446,7 +1446,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -1459,7 +1459,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1482,12 +1482,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1510,12 +1510,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1538,12 +1538,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1566,12 +1566,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -1594,12 +1594,12 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>
@@ -1931,12 +1931,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   ID
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   8fg3ha
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 />
               </tr>
               <tr
@@ -1949,12 +1949,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Type of disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Planned
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                 >
                   <a
                     className="govuk-link"
@@ -1977,12 +1977,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Summary
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2005,12 +2005,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Description
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Road closure due to flooding and cattle on road and no sign of movement example example example etc etc
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2033,12 +2033,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Associated link
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   https://www.flooding.com
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2061,12 +2061,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Reason for disruption
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   Flooding
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2089,7 +2089,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Validity period 1
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     13/01/2022
@@ -2103,7 +2103,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2126,7 +2126,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Validity period 2
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <span>
                     15/01/2022
@@ -2140,7 +2140,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   </span>
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                 >
                   <a
                     className="govuk-link"
@@ -2163,12 +2163,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish start date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2191,12 +2191,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish start time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2219,12 +2219,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish end date
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   13/01/2022
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2247,12 +2247,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                   Publish end time
                 </th>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   14:00
                 </td>
                 <td
-                  className="govuk-table__cell align-middle"
+                  className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                 >
                   <a
                     className="govuk-link"
@@ -2322,12 +2322,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Network wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -2350,12 +2350,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2378,12 +2378,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2406,12 +2406,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2434,12 +2434,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         33 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2515,12 +2515,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Operator wide
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -2543,12 +2543,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Tram
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2571,12 +2571,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Operators affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         FMAN
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2599,12 +2599,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2627,12 +2627,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2655,12 +2655,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         50 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2736,12 +2736,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Consequence type
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/2"
                       >
                         Services
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -2764,12 +2764,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Mode of transport
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Bus
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2792,12 +2792,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Service(s)
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1 - Jordanthorpe - HigH Green (First South Yorkshire)
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2820,12 +2820,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Stops affected
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         N/A
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2848,12 +2848,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Advice to display
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         The road is closed for the following reasons: Example, example, example, example
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2876,12 +2876,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Remove from journey planner
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Yes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -2904,12 +2904,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Disruption delay
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         12 minutes
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3007,12 +3007,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -3035,12 +3035,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         No image uploaded
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3063,12 +3063,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2027
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3091,12 +3091,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3119,12 +3119,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3147,12 +3147,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3175,12 +3175,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>
@@ -3239,12 +3239,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Message to appear
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Test post 12345
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl w-1/10"
                       >
                         <a
                           className="govuk-link"
@@ -3267,7 +3267,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Image
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link text-govBlue"
@@ -3280,7 +3280,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         </a>
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3303,12 +3303,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish date
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         14/01/2028
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3331,12 +3331,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Publish time
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         1300
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3359,12 +3359,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Account name
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3387,12 +3387,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         HootSuite profile
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Twitter/1234
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         <a
                           className="govuk-link"
@@ -3415,12 +3415,12 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                         Status
                       </th>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       >
                         Pending
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl undefined"
                       />
                     </tr>
                   </tbody>

--- a/site/pages/sysadmin/__snapshots__/manage-organisations.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/manage-organisations.test.tsx.snap
@@ -59,19 +59,19 @@ exports[`manageOrganisations > should render correctly when there are no inputs 
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Organisation
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               NaPTAN AdminArea
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Action
@@ -346,19 +346,19 @@ exports[`manageOrganisations > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Organisation
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               NaPTAN AdminArea
             </th>
             <th
-              className="govuk-table__header align-middle"
+              className="govuk-table__header align-middle px-2"
               scope="col"
             >
               Action

--- a/site/pages/sysadmin/__snapshots__/manage-organisations.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/manage-organisations.test.tsx.snap
@@ -372,17 +372,17 @@ exports[`manageOrganisations > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               KPMG
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               001, 002
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <div
                 className="flex"
@@ -418,17 +418,17 @@ exports[`manageOrganisations > should render correctly with inputs 1`] = `
             className="govuk-table__row"
           >
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               KPMG UK
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               003, 004
             </td>
             <td
-              className="govuk-table__cell align-middle"
+              className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
             >
               <div
                 className="flex"

--- a/site/pages/sysadmin/__snapshots__/org.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/org.test.tsx.snap
@@ -670,12 +670,12 @@ exports[`manageOrgs > should render correctly with inputs 1`] = `
                       className="govuk-table__row"
                     >
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         001
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <button
                           className="govuk-link"
@@ -690,12 +690,12 @@ exports[`manageOrgs > should render correctly with inputs 1`] = `
                       className="govuk-table__row"
                     >
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         002
                       </td>
                       <td
-                        className="govuk-table__cell align-middle"
+                        className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
                       >
                         <button
                           className="govuk-link"

--- a/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
@@ -587,22 +587,22 @@ exports[`addUser > should render correctly with inputs 1`] = `
               className="govuk-table__row"
             >
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 dummy
               </td>
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 user1
               </td>
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 dummy.user1@gmail.com
               </td>
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 <button
                   className="govuk-link"
@@ -623,22 +623,22 @@ exports[`addUser > should render correctly with inputs 1`] = `
               className="govuk-table__row"
             >
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 dummy
               </td>
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 user2
               </td>
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 dummy.user2@gmail.com
               </td>
               <td
-                className="govuk-table__cell align-middle"
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
               >
                 <button
                   className="govuk-link"

--- a/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
@@ -165,25 +165,25 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
               className="govuk-table__row"
             >
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 First name
               </th>
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 Last name
               </th>
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 Email
               </th>
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 Action
@@ -555,25 +555,25 @@ exports[`addUser > should render correctly with inputs 1`] = `
               className="govuk-table__row"
             >
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 First name
               </th>
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 Last name
               </th>
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 Email
               </th>
               <th
-                className="govuk-table__header align-middle"
+                className="govuk-table__header align-middle px-2"
                 scope="col"
               >
                 Action

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -31,6 +31,9 @@ module.exports = {
                 3: "3px",
                 10: "10px",
             },
+            width: {
+                "1/10": "10%"
+            },
             spacing: () => ({
                 ...Array.from({ length: 96 }, (_, index) => index * 0.5)
                     .filter((i) => i)

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -32,7 +32,7 @@ module.exports = {
                 10: "10px",
             },
             width: {
-                "1/10": "10%"
+                "1/10": "10%",
             },
             spacing: () => ({
                 ...Array.from({ length: 96 }, (_, index) => index * 0.5)


### PR DESCRIPTION
The fix ensures that the change link column in disruption details and review disruption page are aligned as expected.