### PR TITLE
Fix to not auto display publication fields when there is an error on the field

### DIFF
--- a/site/pages/create-disruption/[disruptionId].page.tsx
+++ b/site/pages/create-disruption/[disruptionId].page.tsx
@@ -387,7 +387,8 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint={{ hidden: false, text: "Enter in format DD/MM/YYYY" }}
                                     value={
                                         pageState.inputs.publishStartDate ||
-                                        validity.disruptionRepeats !== "doesntRepeat"
+                                        validity.disruptionRepeats !== "doesntRepeat" ||
+                                        !!pageState.errors.find((error) => error.id === "publishStartDate")
                                             ? pageState.inputs.publishStartDate
                                             : validity.disruptionStartDate
                                     }
@@ -405,7 +406,8 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     hint="Enter the time in 24hr format. For example 0900 is 9am, 1730 is 5:30pm"
                                     value={
                                         pageState.inputs.publishStartTime ||
-                                        validity.disruptionRepeats !== "doesntRepeat"
+                                        validity.disruptionRepeats !== "doesntRepeat" ||
+                                        !!pageState.errors.find((error) => error.id === "publishStartTime")
                                             ? pageState.inputs.publishStartTime
                                             : validity.disruptionStartTime
                                     }
@@ -424,7 +426,9 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                     display="Publication end date"
                                     hint={{ hidden: true, text: "Enter in format DD/MM/YYYY" }}
                                     value={
-                                        pageState.inputs.publishEndDate || validity.disruptionRepeats !== "doesntRepeat"
+                                        pageState.inputs.publishEndDate ||
+                                        validity.disruptionRepeats !== "doesntRepeat" ||
+                                        !!pageState.errors.find((error) => error.id === "publishEndDate")
                                             ? pageState.inputs.publishEndDate
                                             : validity.disruptionEndDate
                                     }
@@ -439,7 +443,9 @@ const CreateDisruption = (props: DisruptionPageProps): ReactElement => {
                                 <TimeSelector<DisruptionInfo>
                                     display="Publication end time"
                                     value={
-                                        pageState.inputs.publishEndTime || validity.disruptionRepeats !== "doesntRepeat"
+                                        pageState.inputs.publishEndTime ||
+                                        validity.disruptionRepeats !== "doesntRepeat" ||
+                                        !!pageState.errors.find((error) => error.id === "publishEndTime")
                                             ? pageState.inputs.publishEndTime
                                             : validity.disruptionEndTime
                                     }


### PR DESCRIPTION
Currently when the create disruption page is submitted without data in publication fields, the reloaded page with errors has data populated in these fields. The fix ensures that these fields are empty when there is an error