### PR TITLE
feat: sys admin view all users

### DIFF
--- a/site/data/cognito.ts
+++ b/site/data/cognito.ts
@@ -302,27 +302,6 @@ export const createUser = async (userData: AddUserSchema) => {
     );
 };
 
-export const getUsersInGroupAndOrg = async (orgId: string, groupName: string) => {
-    logger.info("", {
-        context: "data.cognito",
-        message: "Listing cognito users in an organisation and in a group",
-    });
-
-    try {
-        const userList = await cognito.send(
-            new ListUsersInGroupCommand({ UserPoolId: userPoolId, GroupName: groupName }),
-        );
-
-        return userList.Users?.filter((user) => user.Attributes?.find((value) => value.Value === orgId)) ?? [];
-    } catch (error) {
-        if (error instanceof Error) {
-            throw new Error(`Failed to list cognito users in organisation ${orgId}: ${error.stack || ""}`);
-        }
-
-        throw error;
-    }
-};
-
 export const initiateResetPassword = async (email: string) => {
     logger.info("", {
         context: "data.cognito",

--- a/site/pages/admin/user-management.page.tsx
+++ b/site/pages/admin/user-management.page.tsx
@@ -37,7 +37,9 @@ const UserManagement = ({ userList, csrfToken }: UserManagementPageProps): React
                     `${getAccountType(user.group)}`,
                     user.email,
                     user.userStatus === "CONFIRMED" ? "Active" : "Pending invite",
-                    createLink("user-action", index, user.username, user.group, user.userStatus !== "CONFIRMED"),
+                    user.group !== "system-admins"
+                        ? createLink("user-action", index, user.username, user.group, user.userStatus !== "CONFIRMED")
+                        : "",
                 ],
             });
         });
@@ -66,42 +68,37 @@ const UserManagement = ({ userList, csrfToken }: UserManagementPageProps): React
         userGroup: string,
         showResendInvite?: boolean,
     ) => {
-        {
-            if (userGroup !== "system-admins") {
-                return (
+        return (
+            <>
+                {showResendInvite ? (
                     <>
-                        {showResendInvite ? (
-                            <>
-                                <button
-                                    key={`${key}${index ? `-${index}` : ""}`}
-                                    className="govuk-link"
-                                    onClick={() => resendInvite(username, userGroup)}
-                                >
-                                    Resend invite
-                                </button>
-                                <br />
-                                <button
-                                    key={`${key}${index ? `-remove-${index}` : "-remove"}`}
-                                    className="govuk-link"
-                                    onClick={() => removeUser(username)}
-                                >
-                                    Remove
-                                </button>
-                            </>
-                        ) : (
-                            <button
-                                key={`${key}${index ? `-${index}` : ""}`}
-                                className="govuk-link"
-                                onClick={() => removeUser(username)}
-                            >
-                                Remove
-                            </button>
-                        )}
+                        <button
+                            key={`${key}${index ? `-${index}` : ""}`}
+                            className="govuk-link"
+                            onClick={() => resendInvite(username, userGroup)}
+                        >
+                            Resend invite
+                        </button>
+                        <br />
+                        <button
+                            key={`${key}${index ? `-remove-${index}` : "-remove"}`}
+                            className="govuk-link"
+                            onClick={() => removeUser(username)}
+                        >
+                            Remove
+                        </button>
                     </>
-                );
-            }
-            return null;
-        }
+                ) : (
+                    <button
+                        key={`${key}${index ? `-${index}` : ""}`}
+                        className="govuk-link"
+                        onClick={() => removeUser(username)}
+                    >
+                        Remove
+                    </button>
+                )}
+            </>
+        );
     };
 
     return (

--- a/site/pages/admin/user-management.page.tsx
+++ b/site/pages/admin/user-management.page.tsx
@@ -1,4 +1,3 @@
-import { UserGroups } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
 import Link from "next/link";
 import { ReactElement, ReactNode, useState } from "react";
@@ -11,6 +10,7 @@ import { listUsersWithGroups } from "../../data/cognito";
 import { UserManagementSchema, userManagementSchema } from "../../schemas/user-management.schema";
 import { getSessionWithOrgDetail } from "../../utils/apiUtils/auth";
 import { getDataInPages } from "../../utils/formUtils";
+import { getAccountType } from "../../utils/tableUtils";
 
 const title = "User Management";
 const description = "User Management page for the Create Transport Disruptions Service";
@@ -28,18 +28,6 @@ const UserManagement = ({ userList, csrfToken }: UserManagementPageProps): React
         username: string;
         userGroup: string;
     } | null>(null);
-
-    const getAccountType = (groupName: UserGroups): string => {
-        switch (groupName) {
-            case UserGroups.systemAdmins:
-            case UserGroups.orgAdmins:
-                return "Admin";
-            case UserGroups.orgPublishers:
-                return "Publisher";
-            case UserGroups.orgStaff:
-                return "Staff";
-        }
-    };
 
     const getRows = () => {
         const rows: { header?: string | ReactNode; cells: string[] | ReactNode[] }[] = [];

--- a/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
@@ -47,7 +47,8 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
       <h1
         className="govuk-heading-l"
       >
-        Add an organisation admin
+        Add 
+         admin
       </h1>
       <p
         className="govuk-body"
@@ -451,7 +452,8 @@ exports[`addUser > should render correctly with inputs 1`] = `
       <h1
         className="govuk-heading-l"
       >
-        Add an organisation admin
+        Add 
+         admin
       </h1>
       <p
         className="govuk-body"

--- a/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
@@ -191,6 +191,12 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
                 className="govuk-table__header align-middle px-2"
                 scope="col"
               >
+                Account Type
+              </th>
+              <th
+                className="govuk-table__header align-middle px-2"
+                scope="col"
+              >
                 Action
               </th>
               <th
@@ -592,6 +598,12 @@ exports[`addUser > should render correctly with inputs 1`] = `
                 className="govuk-table__header align-middle px-2"
                 scope="col"
               >
+                Account Type
+              </th>
+              <th
+                className="govuk-table__header align-middle px-2"
+                scope="col"
+              >
                 Action
               </th>
               <th
@@ -604,76 +616,7 @@ exports[`addUser > should render correctly with inputs 1`] = `
           </thead>
           <tbody
             className="govuk-table__body"
-          >
-            <tr
-              className="govuk-table__row"
-            >
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                dummy
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                user1
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                dummy.user1@gmail.com
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                <button
-                  className="govuk-link"
-                  onClick={[Function]}
-                >
-                  Remove
-                </button>
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                Registered
-              </td>
-            </tr>
-            <tr
-              className="govuk-table__row"
-            >
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                dummy
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                user2
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                dummy.user2@gmail.com
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                <button
-                  className="govuk-link"
-                  onClick={[Function]}
-                >
-                  Remove
-                </button>
-              </td>
-              <td
-                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
-              >
-                Registered
-              </td>
-            </tr>
-          </tbody>
+          />
         </table>
       </form>
     </main>

--- a/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
       <p
         className="govuk-body"
       >
-        Users added below will be set up as admins for their respective organisations. They will have the ability to perform all functionality available within the tool, including the ability to set up further admin users on their own and users with lower permission settings.
+        Users added below will be set up as admins for their respective organisations. They will have the ability to perform all functionality available within the tool, including the ability to set up further admin users on their own and users with lower permission settings. Users of any account type added by the organisations admin will also appear in the list of users below
       </p>
       <form
         action="/api/sysadmin/users"
@@ -74,7 +74,7 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
               className="govuk-label govuk-label--s"
               htmlFor="given-name-input"
             >
-              First name
+              Admin First name
             </label>
             <div
               className=""
@@ -101,7 +101,7 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
               className="govuk-label govuk-label--s"
               htmlFor="family-name-input"
             >
-              Last name
+              Admin Last name
             </label>
             <div
               className=""
@@ -128,7 +128,7 @@ exports[`addUser > should render correctly when there are no inputs 1`] = `
               className="govuk-label govuk-label--s"
               htmlFor="email-input"
             >
-              Email address
+              Admin Email address
             </label>
             <div
               className=""
@@ -456,7 +456,7 @@ exports[`addUser > should render correctly with inputs 1`] = `
       <p
         className="govuk-body"
       >
-        Users added below will be set up as admins for their respective organisations. They will have the ability to perform all functionality available within the tool, including the ability to set up further admin users on their own and users with lower permission settings.
+        Users added below will be set up as admins for their respective organisations. They will have the ability to perform all functionality available within the tool, including the ability to set up further admin users on their own and users with lower permission settings. Users of any account type added by the organisations admin will also appear in the list of users below
       </p>
       <form
         action="/api/sysadmin/users"
@@ -478,7 +478,7 @@ exports[`addUser > should render correctly with inputs 1`] = `
               className="govuk-label govuk-label--s"
               htmlFor="given-name-input"
             >
-              First name
+              Admin First name
             </label>
             <div
               className=""
@@ -506,7 +506,7 @@ exports[`addUser > should render correctly with inputs 1`] = `
               className="govuk-label govuk-label--s"
               htmlFor="family-name-input"
             >
-              Last name
+              Admin Last name
             </label>
             <div
               className=""
@@ -534,7 +534,7 @@ exports[`addUser > should render correctly with inputs 1`] = `
               className="govuk-label govuk-label--s"
               htmlFor="email-input"
             >
-              Email address
+              Admin Email address
             </label>
             <div
               className=""

--- a/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
+++ b/site/pages/sysadmin/__snapshots__/users.test.tsx.snap
@@ -616,7 +616,86 @@ exports[`addUser > should render correctly with inputs 1`] = `
           </thead>
           <tbody
             className="govuk-table__body"
-          />
+          >
+            <tr
+              className="govuk-table__row"
+            >
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                dummy
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                user1
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                dummy.user1@gmail.com
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                Admin
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                <button
+                  className="govuk-link"
+                  onClick={[Function]}
+                >
+                  Remove
+                </button>
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                Registered
+              </td>
+            </tr>
+            <tr
+              className="govuk-table__row"
+            >
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                dummy
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                user2
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                dummy.user2@gmail.com
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                Admin
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                <button
+                  className="govuk-link"
+                  onClick={[Function]}
+                >
+                  Remove
+                </button>
+              </td>
+              <td
+                className="govuk-table__cell align-middle overflow-hidden px-2 max-w-2xl "
+              >
+                Registered
+              </td>
+            </tr>
+          </tbody>
         </table>
       </form>
     </main>

--- a/site/pages/sysadmin/users.page.tsx
+++ b/site/pages/sysadmin/users.page.tsx
@@ -184,7 +184,7 @@ const SysAdminUserManagement = (props: SysAdminUserManagementProps): ReactElemen
             </p>
             <CsrfForm action="/api/sysadmin/users" method="post" csrfToken={props.csrfToken}>
                 <TextInput<AddUserSchema>
-                    display="First name"
+                    display="Admin First name"
                     inputName="givenName"
                     widthClass="w"
                     value={pageState.inputs.givenName}
@@ -194,7 +194,7 @@ const SysAdminUserManagement = (props: SysAdminUserManagementProps): ReactElemen
                     maxLength={100}
                 />
                 <TextInput<AddUserSchema>
-                    display="Last name"
+                    display="Admin Last name"
                     inputName="familyName"
                     widthClass="w"
                     value={pageState.inputs.familyName}
@@ -204,7 +204,7 @@ const SysAdminUserManagement = (props: SysAdminUserManagementProps): ReactElemen
                     maxLength={100}
                 />
                 <TextInput<AddUserSchema>
-                    display="Email address"
+                    display="Admin Email address"
                     inputName="email"
                     widthClass="w"
                     value={pageState.inputs.email}

--- a/site/pages/sysadmin/users.page.tsx
+++ b/site/pages/sysadmin/users.page.tsx
@@ -179,7 +179,8 @@ const SysAdminUserManagement = (props: SysAdminUserManagementProps): ReactElemen
             <p className="govuk-body">
                 Users added below will be set up as admins for their respective organisations. They will have the
                 ability to perform all functionality available within the tool, including the ability to set up further
-                admin users on their own and users with lower permission settings.
+                admin users on their own and users with lower permission settings. Users of any account type added by
+                the organisations admin will also appear in the list of users below
             </p>
             <CsrfForm action="/api/sysadmin/users" method="post" csrfToken={props.csrfToken}>
                 <TextInput<AddUserSchema>

--- a/site/pages/sysadmin/users.page.tsx
+++ b/site/pages/sysadmin/users.page.tsx
@@ -46,14 +46,16 @@ const SysAdminUserManagement = (props: SysAdminUserManagementProps): ReactElemen
                     user.familyName,
                     user.email,
                     `${getAccountType(user.group)}`,
-                    createLink(
-                        "user-action",
-                        index,
-                        user.username,
-                        user.group,
-                        user.organisation,
-                        user.userStatus !== "CONFIRMED" && user.group == "org-admins",
-                    ),
+                    user.group !== "system-admins"
+                        ? createLink(
+                              "user-action",
+                              index,
+                              user.username,
+                              user.group,
+                              user.organisation,
+                              user.userStatus !== "CONFIRMED" && user.group == "org-admins",
+                          )
+                        : "",
                     user.userStatus === "FORCE_CHANGE_PASSWORD" ? "Unregistered" : "Registered",
                 ],
             });

--- a/site/pages/sysadmin/users.test.tsx
+++ b/site/pages/sysadmin/users.test.tsx
@@ -1,18 +1,18 @@
 import { UserGroups } from "@create-disruptions-data/shared-ts/enums";
 import renderer from "react-test-renderer";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import AdminUsers, { AdminUserProps } from "./users.page";
+import SysAdminUserManagement, { SysAdminUserManagementProps } from "./users.page";
 import { defaultModes } from "../../schemas/organisation.schema";
 import { SessionWithOrgDetail } from "../../schemas/session.schema";
 import * as session from "../../utils/apiUtils/auth";
 
-const blankInputs: AdminUserProps = {
+const blankInputs: SysAdminUserManagementProps = {
     inputs: {},
     errors: [],
 };
 
 const randomId = "016f954c-0e14-11ee-be56-0242ac120002";
-const withInputs: AdminUserProps = {
+const withInputs: SysAdminUserManagementProps = {
     inputs: {
         givenName: "dummy",
         familyName: "user",
@@ -20,7 +20,7 @@ const withInputs: AdminUserProps = {
         group: UserGroups.orgAdmins,
     },
     errors: [],
-    admins: [
+    users: [
         {
             userStatus: "CONFIRMED",
             username: randomId,
@@ -28,6 +28,7 @@ const withInputs: AdminUserProps = {
             familyName: "user1",
             email: "dummy.user1@gmail.com",
             organisation: randomId,
+            group: UserGroups.orgAdmins,
         },
         {
             userStatus: "CONFIRMED",
@@ -36,6 +37,7 @@ const withInputs: AdminUserProps = {
             familyName: "user2",
             email: "dummy.user2@gmail.com",
             organisation: randomId,
+            group: UserGroups.orgAdmins,
         },
     ],
 };
@@ -76,12 +78,12 @@ describe("addUser", () => {
     });
 
     it("should render correctly when there are no inputs", () => {
-        const tree = renderer.create(<AdminUsers {...blankInputs} />).toJSON();
+        const tree = renderer.create(<SysAdminUserManagement {...blankInputs} />).toJSON();
         expect(tree).toMatchSnapshot();
     });
 
     it("should render correctly with inputs", () => {
-        const tree = renderer.create(<AdminUsers {...withInputs} />).toJSON();
+        const tree = renderer.create(<SysAdminUserManagement {...withInputs} />).toJSON();
         expect(tree).toMatchSnapshot();
     });
 });

--- a/site/schemas/user-management.schema.ts
+++ b/site/schemas/user-management.schema.ts
@@ -94,41 +94,6 @@ export const userManagementSchema = z.array(
 
 export type UserManagementSchema = z.infer<typeof userManagementSchema>;
 
-export const adminSchema = z.array(
-    z
-        .object({
-            Attributes: z.array(
-                z.object({
-                    Name: z.string(),
-                    Value: z.string(),
-                }),
-            ),
-            UserStatus: z.string(),
-            Username: z.string(),
-        })
-        .transform((item) =>
-            item.Attributes.reduce(
-                (p, c) => ({
-                    ...p,
-                    givenName: c.Name === "given_name" ? c.Value : p.givenName,
-                    familyName: c.Name === "family_name" ? c.Value : p.familyName,
-                    email: c.Name === "email" ? c.Value : p.email,
-                    organisation: c.Name === "custom:orgId" ? c.Value : p.organisation,
-                }),
-                {
-                    userStatus: item.UserStatus,
-                    username: item.Username,
-                    givenName: "N/A",
-                    familyName: "N/A",
-                    email: "N/A",
-                    organisation: "N/A",
-                },
-            ),
-        ),
-);
-
-export type AdminSchema = z.infer<typeof adminSchema>;
-
 export const orgIdSchema = z.object({
     orgId: z.string(),
 });

--- a/site/utils/tableUtils.ts
+++ b/site/utils/tableUtils.ts
@@ -1,0 +1,14 @@
+import { UserGroups } from "@create-disruptions-data/shared-ts/enums";
+
+export const getAccountType = (groupName: UserGroups): string => {
+    switch (groupName) {
+        case UserGroups.systemAdmins:
+            return "System Admin";
+        case UserGroups.orgAdmins:
+            return "Admin";
+        case UserGroups.orgPublishers:
+            return "Publisher";
+        case UserGroups.orgStaff:
+            return "Staff";
+    }
+};


### PR DESCRIPTION
Added functionality for system admins to be able to view all user types for a given organisation. System admins should be able to remove all user types, but can only resend invites to org admins. 

System admins should be able to view other system admins, but not perform any actions.