### PR TITLE
fix: Error page found when change link is selected on existing template

### DIFF
--- a/site/components/ReviewConsequenceTable.tsx
+++ b/site/components/ReviewConsequenceTable.tsx
@@ -32,7 +32,7 @@ const getConsequenceUrl = (type: Consequence["consequenceType"]) => {
 export const createChangeLink = (
     key: string,
     href: string,
-    disruption: FullDisruption,
+    disruptionId: string,
     index?: number,
     includePreviousPage?: boolean,
     isDisruptionDetail?: boolean,
@@ -43,10 +43,13 @@ export const createChangeLink = (
             key={key}
             className="govuk-link"
             href={{
-                pathname: `${href}/${disruption.disruptionId}${index !== undefined ? `/${index}` : ""}`,
+                pathname: `${href}/${disruptionId}${index !== undefined ? `/${index}` : ""}`,
                 query: includePreviousPage
                     ? {
-                          return: isDisruptionDetail ? DISRUPTION_DETAIL_PAGE_PATH : REVIEW_DISRUPTION_PAGE_PATH,
+                          return:
+                              isDisruptionDetail || isTemplate
+                                  ? DISRUPTION_DETAIL_PAGE_PATH
+                                  : REVIEW_DISRUPTION_PAGE_PATH,
                           ...(isTemplate ? { template: isTemplate.toString() } : {}),
                       }
                     : isTemplate
@@ -79,7 +82,7 @@ const getRows = (
                     value: createChangeLink(
                         "consequence-type",
                         TYPE_OF_CONSEQUENCE_PAGE_PATH,
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -99,7 +102,7 @@ const getRows = (
                     value: createChangeLink(
                         "vehicle-mode",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -126,7 +129,7 @@ const getRows = (
                     value: createChangeLink(
                         "service",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -156,7 +159,7 @@ const getRows = (
                     value: createChangeLink(
                         "stops-affected",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -180,7 +183,7 @@ const getRows = (
                     value: createChangeLink(
                         "operators-affected",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -202,7 +205,7 @@ const getRows = (
                     value: createChangeLink(
                         "advice-to-display",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -221,7 +224,7 @@ const getRows = (
                     value: createChangeLink(
                         "remove-from-journey-planners",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,
@@ -240,7 +243,7 @@ const getRows = (
                     value: createChangeLink(
                         "disruption-delay",
                         getConsequenceUrl(consequence.consequenceType),
-                        disruption,
+                        disruption.disruptionId,
                         consequence.consequenceIndex,
                         true,
                         isDisruptionDetail,

--- a/site/components/ReviewConsequenceTable.tsx
+++ b/site/components/ReviewConsequenceTable.tsx
@@ -13,7 +13,6 @@ import {
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     VEHICLE_MODES,
 } from "../constants";
-import { FullDisruption } from "../schemas/disruption.schema";
 import { getDisplayByValue, splitCamelCaseToString } from "../utils";
 
 const getConsequenceUrl = (type: Consequence["consequenceType"]) => {

--- a/site/pages/api/create-consequence-network.api.ts
+++ b/site/pages/api/create-consequence-network.api.ts
@@ -65,7 +65,9 @@ const createConsequenceNetwork = async (req: NextApiRequest, res: NextApiRespons
         destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_NETWORK_ERRORS, res);
 
         const redirectPath =
-            !isFromTemplate && queryParam && decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
+            (!isFromTemplate || template) &&
+            queryParam &&
+            decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
                 ? DISRUPTION_DETAIL_PAGE_PATH
                 : REVIEW_DISRUPTION_PAGE_PATH;
 

--- a/site/pages/api/create-consequence-operator.api.ts
+++ b/site/pages/api/create-consequence-operator.api.ts
@@ -92,7 +92,9 @@ const createConsequenceOperator = async (req: OperatorConsequenceRequest, res: N
         destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_OPERATOR_ERRORS, res);
 
         const redirectPath =
-            !isFromTemplate && queryParam && decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
+            (!isFromTemplate || template) &&
+            queryParam &&
+            decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
                 ? DISRUPTION_DETAIL_PAGE_PATH
                 : REVIEW_DISRUPTION_PAGE_PATH;
 

--- a/site/pages/api/create-consequence-services.api.ts
+++ b/site/pages/api/create-consequence-services.api.ts
@@ -98,7 +98,9 @@ const createConsequenceServices = async (req: NextApiRequest, res: NextApiRespon
         destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_SERVICES_ERRORS, res);
 
         const redirectPath =
-            !isFromTemplate && queryParam && decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
+            (!isFromTemplate || template) &&
+            queryParam &&
+            decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
                 ? DISRUPTION_DETAIL_PAGE_PATH
                 : REVIEW_DISRUPTION_PAGE_PATH;
 

--- a/site/pages/api/create-consequence-stops.api.ts
+++ b/site/pages/api/create-consequence-stops.api.ts
@@ -85,7 +85,9 @@ const createConsequenceStops = async (req: NextApiRequest, res: NextApiResponse)
         destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_STOPS_ERRORS, res);
 
         const redirectPath =
-            !isFromTemplate && queryParam && decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
+            (!isFromTemplate || template) &&
+            queryParam &&
+            decodeURIComponent(queryParam).includes(DISRUPTION_DETAIL_PAGE_PATH)
                 ? DISRUPTION_DETAIL_PAGE_PATH
                 : REVIEW_DISRUPTION_PAGE_PATH;
 

--- a/site/pages/api/create-disruption.api.ts
+++ b/site/pages/api/create-disruption.api.ts
@@ -126,7 +126,7 @@ const createDisruption = async (req: NextApiRequest, res: NextApiResponse): Prom
 
         destroyCookieOnResponseObject(COOKIES_DISRUPTION_ERRORS, res);
 
-        queryParam && !isFromTemplate
+        queryParam && (!isFromTemplate || template)
             ? redirectToWithQueryParams(
                   req,
                   res,
@@ -139,9 +139,8 @@ const createDisruption = async (req: NextApiRequest, res: NextApiResponse): Prom
                   req,
                   res,
                   template ? ["template"] : [],
-                  `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${validatedBody.data.disruptionId}/0${
-                      isFromTemplate ? `?${isFromTemplate}` : ""
-                  }`,
+                  `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${validatedBody.data.disruptionId}/0`,
+                  isFromTemplate && !template ? ["template=true"] : [],
               );
 
         return;

--- a/site/pages/api/create-disruption.api.ts
+++ b/site/pages/api/create-disruption.api.ts
@@ -140,7 +140,7 @@ const createDisruption = async (req: NextApiRequest, res: NextApiResponse): Prom
                   res,
                   template ? ["template"] : [],
                   `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${validatedBody.data.disruptionId}/0`,
-                  isFromTemplate && !template ? ["template=true"] : [],
+                  isFromTemplate ? [`${isFromTemplate}`] : [],
               );
 
         return;

--- a/site/pages/api/create-disruption.test.ts
+++ b/site/pages/api/create-disruption.test.ts
@@ -1012,7 +1012,7 @@ describe("create-disruption API", () => {
             false,
         );
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: `/type-of-consequence/${defaultDisruptionId}/0?${returnPath}`,
+            Location: `/type-of-consequence/${defaultDisruptionId}/0?template=true`,
         });
     });
 

--- a/site/pages/api/create-disruption.test.ts
+++ b/site/pages/api/create-disruption.test.ts
@@ -1012,7 +1012,7 @@ describe("create-disruption API", () => {
             false,
         );
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: `/type-of-consequence/${defaultDisruptionId}/0?template=true`,
+            Location: `/type-of-consequence/${defaultDisruptionId}/0?${returnPath}`,
         });
     });
 

--- a/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
@@ -172,10 +172,10 @@ const CreateConsequenceNetwork = (props: CreateConsequenceNetworkProps): ReactEl
                                 role="button"
                                 href={
                                     returnToTemplateOverview
-                                        ? (queryParams["return"] as string)
-                                        : `${queryParams["return"] as string}/${pageState.disruptionId}${
+                                        ? `${queryParams["return"] as string}/${pageState.disruptionId || ""}${
                                               isTemplate ? "?template=true" : ""
                                           }`
+                                        : `${queryParams["return"] as string}/${pageState.disruptionId || ""}`
                                 }
                                 className="govuk-button mt-8 ml-5 govuk-button--secondary"
                             >

--- a/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
@@ -27,6 +27,7 @@ import { isNetworkConsequence } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSession } from "../../../utils/apiUtils/auth";
 import { getStateUpdater, returnTemplateOverview, showCancelButton } from "../../../utils/formUtils";
+import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 
 const title = "Create Consequence Network";
 const description = "Create Consequence Network page for the Create Transport Disruptions Service";
@@ -62,15 +63,15 @@ const CreateConsequenceNetwork = (props: CreateConsequenceNetworkProps): ReactEl
                                     header: "Consequence type",
                                     cells: [
                                         "Network wide",
-                                        <Link
-                                            key={"consequence-type"}
-                                            className="govuk-link"
-                                            href={`${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${pageState.disruptionId || ""}/${
-                                                pageState.consequenceIndex ?? 0
-                                            }`}
-                                        >
-                                            Change
-                                        </Link>,
+                                        createChangeLink(
+                                            "consequence-type",
+                                            TYPE_OF_CONSEQUENCE_PAGE_PATH,
+                                            pageState.disruptionId || "",
+                                            pageState.consequenceIndex ?? 0,
+                                            returnToTemplateOverview,
+                                            returnToTemplateOverview,
+                                            !!isTemplate,
+                                        ),
                                     ],
                                 },
                             ]}

--- a/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
@@ -14,6 +14,7 @@ import Table from "../../../components/form/Table";
 import TextInput from "../../../components/form/TextInput";
 import TimeSelector from "../../../components/form/TimeSelector";
 import { BaseLayout } from "../../../components/layout/Layout";
+import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 import {
     COOKIES_CONSEQUENCE_NETWORK_ERRORS,
     CREATE_CONSEQUENCE_NETWORK_PATH,
@@ -28,7 +29,6 @@ import { isNetworkConsequence } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSession } from "../../../utils/apiUtils/auth";
 import { getStateUpdater, returnTemplateOverview, showCancelButton } from "../../../utils/formUtils";
-import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 
 const title = "Create Consequence Network";
 const description = "Create Consequence Network page for the Create Transport Disruptions Service";

--- a/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
@@ -17,6 +17,7 @@ import { BaseLayout } from "../../../components/layout/Layout";
 import {
     COOKIES_CONSEQUENCE_NETWORK_ERRORS,
     CREATE_CONSEQUENCE_NETWORK_PATH,
+    DISRUPTION_DETAIL_PAGE_PATH,
     DISRUPTION_SEVERITIES,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     VEHICLE_MODES,
@@ -68,8 +69,9 @@ const CreateConsequenceNetwork = (props: CreateConsequenceNetworkProps): ReactEl
                                             TYPE_OF_CONSEQUENCE_PAGE_PATH,
                                             pageState.disruptionId || "",
                                             pageState.consequenceIndex ?? 0,
-                                            returnToTemplateOverview,
-                                            returnToTemplateOverview,
+                                            returnToTemplateOverview || !!queryParams["return"],
+                                            returnToTemplateOverview ||
+                                                queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH),
                                             !!isTemplate,
                                         ),
                                     ],

--- a/site/pages/create-consequence-network/__snapshots__/create-consequence-network.test.tsx.snap
+++ b/site/pages/create-consequence-network/__snapshots__/create-consequence-network.test.tsx.snap
@@ -1275,7 +1275,7 @@ exports[`pages > CreateConsequenceNetwork > should render correctly with query p
                 >
                   <a
                     className="govuk-link"
-                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0"
+                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0?return=%2Freview-disruption"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -15,6 +15,7 @@ import Table from "../../../components/form/Table";
 import TextInput from "../../../components/form/TextInput";
 import TimeSelector from "../../../components/form/TimeSelector";
 import { BaseLayout } from "../../../components/layout/Layout";
+import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 import OperatorSearch from "../../../components/search/OperatorSearch";
 import {
     COOKIES_CONSEQUENCE_OPERATOR_ERRORS,
@@ -112,15 +113,15 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                                     header: "Consequence type",
                                     cells: [
                                         "Operator wide",
-                                        <Link
-                                            key={"consequence-type"}
-                                            className="govuk-link"
-                                            href={`${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${pageState.disruptionId || ""}/${
-                                                pageState.consequenceIndex ?? 0
-                                            }`}
-                                        >
-                                            Change
-                                        </Link>,
+                                        createChangeLink(
+                                            "consequence-type",
+                                            TYPE_OF_CONSEQUENCE_PAGE_PATH,
+                                            pageState.disruptionId || "",
+                                            pageState.consequenceIndex ?? 0,
+                                            returnToTemplateOverview,
+                                            returnToTemplateOverview,
+                                            !!isTemplate,
+                                        ),
                                     ],
                                 },
                             ]}

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -20,6 +20,7 @@ import OperatorSearch from "../../../components/search/OperatorSearch";
 import {
     COOKIES_CONSEQUENCE_OPERATOR_ERRORS,
     CREATE_CONSEQUENCE_OPERATOR_PATH,
+    DISRUPTION_DETAIL_PAGE_PATH,
     DISRUPTION_SEVERITIES,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     VEHICLE_MODES,
@@ -118,8 +119,9 @@ const CreateConsequenceOperator = (props: CreateConsequenceOperatorProps): React
                                             TYPE_OF_CONSEQUENCE_PAGE_PATH,
                                             pageState.disruptionId || "",
                                             pageState.consequenceIndex ?? 0,
-                                            returnToTemplateOverview,
-                                            returnToTemplateOverview,
+                                            returnToTemplateOverview || !!queryParams["return"],
+                                            returnToTemplateOverview ||
+                                                queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH),
                                             !!isTemplate,
                                         ),
                                     ],

--- a/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
+++ b/site/pages/create-consequence-operator/__snapshots__/create-consequence-operator.test.tsx.snap
@@ -1557,7 +1557,7 @@ exports[`pages > CreateConsequenceOperator > should render correctly with query 
                 >
                   <a
                     className="govuk-link"
-                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0"
+                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0?return=%2Freview-disruption"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -29,6 +29,7 @@ import {
     COOKIES_CONSEQUENCE_SERVICES_ERRORS,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     CREATE_CONSEQUENCE_SERVICES_PATH,
+    DISRUPTION_DETAIL_PAGE_PATH,
 } from "../../../constants";
 import { getDisruptionById } from "../../../data/dynamo";
 import { fetchServiceRoutes, fetchServiceStops, fetchServices } from "../../../data/refDataApi";
@@ -401,8 +402,9 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                                             TYPE_OF_CONSEQUENCE_PAGE_PATH,
                                             pageState.disruptionId || "",
                                             pageState.consequenceIndex ?? 0,
-                                            returnToTemplateOverview,
-                                            returnToTemplateOverview,
+                                            returnToTemplateOverview || !!queryParams["return"],
+                                            returnToTemplateOverview ||
+                                                queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH),
                                             !!isTemplate,
                                         ),
                                     ],

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -47,6 +47,7 @@ import {
     showCancelButton,
     sortAndFilterStops,
 } from "../../../utils/formUtils";
+import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 
 const title = "Create Consequence Services";
 const description = "Create Consequence Services page for the Create Transport Disruptions Service";
@@ -395,15 +396,15 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                                     header: "Consequence type",
                                     cells: [
                                         "Services",
-                                        <Link
-                                            key={"consequence-type"}
-                                            className="govuk-link"
-                                            href={`${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${pageState.disruptionId || ""}/${
-                                                pageState.consequenceIndex ?? 0
-                                            }`}
-                                        >
-                                            Change
-                                        </Link>,
+                                        createChangeLink(
+                                            "consequence-type",
+                                            TYPE_OF_CONSEQUENCE_PAGE_PATH,
+                                            pageState.disruptionId || "",
+                                            pageState.consequenceIndex ?? 0,
+                                            returnToTemplateOverview,
+                                            returnToTemplateOverview,
+                                            !!isTemplate,
+                                        ),
                                     ],
                                 },
                             ]}

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -23,6 +23,7 @@ import TextInput from "../../../components/form/TextInput";
 import TimeSelector from "../../../components/form/TimeSelector";
 import { BaseLayout } from "../../../components/layout/Layout";
 import Map from "../../../components/map/ServicesMap";
+import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 import {
     DISRUPTION_SEVERITIES,
     VEHICLE_MODES,
@@ -48,7 +49,6 @@ import {
     showCancelButton,
     sortAndFilterStops,
 } from "../../../utils/formUtils";
-import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 
 const title = "Create Consequence Services";
 const description = "Create Consequence Services page for the Create Transport Disruptions Service";

--- a/site/pages/create-consequence-services/__snapshots__/create-consequence-services.test.tsx.snap
+++ b/site/pages/create-consequence-services/__snapshots__/create-consequence-services.test.tsx.snap
@@ -3161,7 +3161,7 @@ exports[`pages > CreateConsequenceServices > should render correctly with query 
                 >
                   <a
                     className="govuk-link"
-                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0"
+                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0?return=%2Freview-disruption"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}

--- a/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
@@ -18,6 +18,7 @@ import TextInput from "../../../components/form/TextInput";
 import TimeSelector from "../../../components/form/TimeSelector";
 import { BaseLayout } from "../../../components/layout/Layout";
 import Map from "../../../components/map/StopsMap";
+import { createChangeLink } from "../../../components/ReviewConsequenceTable";
 import {
     DISRUPTION_SEVERITIES,
     VEHICLE_MODES,
@@ -197,15 +198,15 @@ const CreateConsequenceStops = (props: CreateConsequenceStopsProps): ReactElemen
                                     header: "Consequence type",
                                     cells: [
                                         "Stops",
-                                        <Link
-                                            key={"consequence-type"}
-                                            className="govuk-link"
-                                            href={`${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${pageState.disruptionId || ""}/${
-                                                pageState.consequenceIndex ?? 0
-                                            }`}
-                                        >
-                                            Change
-                                        </Link>,
+                                        createChangeLink(
+                                            "consequence-type",
+                                            TYPE_OF_CONSEQUENCE_PAGE_PATH,
+                                            pageState.disruptionId || "",
+                                            pageState.consequenceIndex ?? 0,
+                                            returnToTemplateOverview,
+                                            returnToTemplateOverview,
+                                            !!isTemplate,
+                                        ),
                                     ],
                                 },
                             ]}

--- a/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
@@ -25,6 +25,7 @@ import {
     COOKIES_CONSEQUENCE_STOPS_ERRORS,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     CREATE_CONSEQUENCE_STOPS_PATH,
+    DISRUPTION_DETAIL_PAGE_PATH,
 } from "../../../constants";
 import { getDisruptionById } from "../../../data/dynamo";
 import { fetchStops } from "../../../data/refDataApi";
@@ -203,8 +204,9 @@ const CreateConsequenceStops = (props: CreateConsequenceStopsProps): ReactElemen
                                             TYPE_OF_CONSEQUENCE_PAGE_PATH,
                                             pageState.disruptionId || "",
                                             pageState.consequenceIndex ?? 0,
-                                            returnToTemplateOverview,
-                                            returnToTemplateOverview,
+                                            returnToTemplateOverview || !!queryParams["return"],
+                                            returnToTemplateOverview ||
+                                                queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH),
                                             !!isTemplate,
                                         ),
                                     ],

--- a/site/pages/create-consequence-stops/__snapshots__/create-consequence-stops.test.tsx.snap
+++ b/site/pages/create-consequence-stops/__snapshots__/create-consequence-stops.test.tsx.snap
@@ -2425,7 +2425,7 @@ exports[`pages > CreateConsequenceStops > should render correctly with query par
                 >
                   <a
                     className="govuk-link"
-                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0"
+                    href="/type-of-consequence/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/0?return=%2Freview-disruption"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -94,7 +94,7 @@ const DisruptionDetail = ({
                             ? createChangeLink(
                                   "message-to-appear",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   true,
@@ -124,7 +124,7 @@ const DisruptionDetail = ({
                             ? createChangeLink(
                                   "hootsuite-profile",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   true,
@@ -145,7 +145,7 @@ const DisruptionDetail = ({
                             ? createChangeLink(
                                   "publish-date",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   true,
@@ -166,7 +166,7 @@ const DisruptionDetail = ({
                             ? createChangeLink(
                                   "publish-time",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   true,
@@ -187,7 +187,7 @@ const DisruptionDetail = ({
                             ? createChangeLink(
                                   "account-to-publish",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   true,
@@ -208,7 +208,7 @@ const DisruptionDetail = ({
                             ? createChangeLink(
                                   "hootsuite-profile",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   true,
@@ -316,7 +316,7 @@ const DisruptionDetail = ({
                     createChangeLink(
                         `validity-period-${i + 1}`,
                         "/create-disruption",
-                        disruption,
+                        disruption.disruptionId,
                         undefined,
                         true,
                         true,
@@ -423,7 +423,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "type-of-disruption",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -445,7 +445,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "summary",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -464,7 +464,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "description",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -483,7 +483,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "associated-link",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -502,7 +502,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "disruption-reason",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -522,7 +522,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "publish-start-date",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -541,7 +541,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "publish-start-time",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -560,7 +560,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "publish-end-date",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,
@@ -581,7 +581,7 @@ const DisruptionDetail = ({
                                             value: createChangeLink(
                                                 "publish-end-time",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 true,

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -641,7 +641,10 @@ const DisruptionDetail = ({
                         <Link
                             href={{
                                 pathname: `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${disruption.disruptionId}/${nextIndex}`,
-                                query: { return: DISRUPTION_DETAIL_PAGE_PATH },
+                                query: {
+                                    return: DISRUPTION_DETAIL_PAGE_PATH,
+                                    ...(disruption.template ? { template: disruption.template?.toString() } : {}),
+                                },
                             }}
                             className={`govuk-button mt-2 govuk-button--secondary ${
                                 disruption.consequences && disruption.consequences.length >= 10

--- a/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
+++ b/site/pages/disruption-detail/__snapshots__/disruption-detail.test.tsx.snap
@@ -2944,7 +2944,7 @@ exports[`pages > DisruptionDetail > should render correctly with inputs and no e
           </div>
           <a
             className="govuk-button mt-2 govuk-button--secondary "
-            href="/type-of-consequence/2/3?return=%2Fdisruption-detail"
+            href="/type-of-consequence/2/3?return=%2Fdisruption-detail&template=true"
             onClick={[Function]}
             onMouseEnter={[Function]}
             onTouchStart={[Function]}

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -599,7 +599,10 @@ const ReviewDisruption = ({
                         <Link
                             href={{
                                 pathname: `${TYPE_OF_CONSEQUENCE_PAGE_PATH}/${disruption.disruptionId}/${nextIndex}`,
-                                query: { return: REVIEW_DISRUPTION_PAGE_PATH, template: queryParams["template"] },
+                                query: {
+                                    return: REVIEW_DISRUPTION_PAGE_PATH,
+                                    ...(disruption.template ? { template: disruption.template?.toString() } : {}),
+                                },
                             }}
                             className={`govuk-button mt-2 govuk-button--secondary ${
                                 disruption.consequences && disruption.consequences.length >= 10

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -302,7 +302,13 @@ const ReviewDisruption = ({
                     ) : (
                         `${validity.disruptionStartDate} ${validity.disruptionStartTime} - No end date/time`
                     ),
-                    createChangeLink(`validity-period-${i + 1}`, "/create-disruption", disruption.disruptionId, undefined, true),
+                    createChangeLink(
+                        `validity-period-${i + 1}`,
+                        "/create-disruption",
+                        disruption.disruptionId,
+                        undefined,
+                        true,
+                    ),
                     false,
                     disruption.template,
                     ,

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -77,7 +77,7 @@ const ReviewDisruption = ({
                             ? createChangeLink(
                                   "message-to-appear",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   false,
@@ -107,7 +107,7 @@ const ReviewDisruption = ({
                             ? createChangeLink(
                                   "hootsuite-profile",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   false,
@@ -128,7 +128,7 @@ const ReviewDisruption = ({
                             ? createChangeLink(
                                   "publish-date",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   false,
@@ -149,7 +149,7 @@ const ReviewDisruption = ({
                             ? createChangeLink(
                                   "publish-time",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   false,
@@ -170,7 +170,7 @@ const ReviewDisruption = ({
                             ? createChangeLink(
                                   "account-to-publish",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   false,
@@ -191,7 +191,7 @@ const ReviewDisruption = ({
                             ? createChangeLink(
                                   "hootsuite-profile",
                                   CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
-                                  disruption,
+                                  disruption.disruptionId,
                                   post.socialMediaPostIndex,
                                   true,
                                   false,
@@ -302,7 +302,7 @@ const ReviewDisruption = ({
                     ) : (
                         `${validity.disruptionStartDate} ${validity.disruptionStartTime} - No end date/time`
                     ),
-                    createChangeLink(`validity-period-${i + 1}`, "/create-disruption", disruption, undefined, true),
+                    createChangeLink(`validity-period-${i + 1}`, "/create-disruption", disruption.disruptionId, undefined, true),
                     false,
                     disruption.template,
                     ,
@@ -381,7 +381,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "type-of-disruption",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -403,7 +403,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "summary",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -422,7 +422,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "description",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -441,7 +441,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "associated-link",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -460,7 +460,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "disruption-reason",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -480,7 +480,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "publish-start-date",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -499,7 +499,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "publish-start-time",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -518,7 +518,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "publish-end-date",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,
@@ -539,7 +539,7 @@ const ReviewDisruption = ({
                                             value: createChangeLink(
                                                 "publish-end-time",
                                                 "/create-disruption",
-                                                disruption,
+                                                disruption.disruptionId,
                                                 undefined,
                                                 true,
                                                 false,

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -3799,7 +3799,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -3827,7 +3827,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -3855,7 +3855,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -3883,7 +3883,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -3911,7 +3911,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -4025,7 +4025,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -4053,7 +4053,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -4081,7 +4081,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -4109,7 +4109,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                 >
                   <a
                     className="govuk-link"
-                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Freview-disruption&template=true"
+                    href="/create-disruption/acde070d-8c4c-4f0d-9d8a-162843c10333?return=%2Fdisruption-detail&template=true"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onTouchStart={[Function]}
@@ -4184,7 +4184,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4212,7 +4212,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4240,7 +4240,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4268,7 +4268,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4296,7 +4296,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-network/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4377,7 +4377,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4405,7 +4405,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4433,7 +4433,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4461,7 +4461,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4489,7 +4489,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4517,7 +4517,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-operator/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4598,7 +4598,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4626,7 +4626,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4654,7 +4654,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4682,7 +4682,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4710,7 +4710,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4738,7 +4738,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4766,7 +4766,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Freview-disruption&template=true"
+                          href="/create-consequence-services/acde070d-8c4c-4f0d-9d8a-162843c10333/2?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4868,7 +4868,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4896,7 +4896,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4924,7 +4924,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4952,7 +4952,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -4980,7 +4980,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5008,7 +5008,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/0?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5100,7 +5100,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5136,7 +5136,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5164,7 +5164,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5192,7 +5192,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5220,7 +5220,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}
@@ -5248,7 +5248,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
                       >
                         <a
                           className="govuk-link"
-                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Freview-disruption&template=true"
+                          href="/create-social-media-post/acde070d-8c4c-4f0d-9d8a-162843c10333/1?return=%2Fdisruption-detail&template=true"
                           onClick={[Function]}
                           onMouseEnter={[Function]}
                           onTouchStart={[Function]}

--- a/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
+++ b/site/pages/review-disruption/__snapshots__/review-disruption.test.tsx.snap
@@ -1134,7 +1134,7 @@ exports[`pages > ReviewDisruption > should render correctly with banner when dis
           </div>
           <a
             className="govuk-button mt-2 govuk-button--secondary "
-            href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/3?return=%2Freview-disruption&template="
+            href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/3?return=%2Freview-disruption"
             onClick={[Function]}
             onMouseEnter={[Function]}
             onTouchStart={[Function]}
@@ -2965,7 +2965,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
           </div>
           <a
             className="govuk-button mt-2 govuk-button--secondary "
-            href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/3?return=%2Freview-disruption&template="
+            href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/3?return=%2Freview-disruption"
             onClick={[Function]}
             onMouseEnter={[Function]}
             onTouchStart={[Function]}
@@ -4796,7 +4796,7 @@ exports[`pages > ReviewDisruption > should render correctly with inputs and no e
           </div>
           <a
             className="govuk-button mt-2 govuk-button--secondary "
-            href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/3?return=%2Freview-disruption&template="
+            href="/type-of-consequence/acde070d-8c4c-4f0d-9d8a-162843c10333/3?return=%2Freview-disruption&template=true"
             onClick={[Function]}
             onMouseEnter={[Function]}
             onTouchStart={[Function]}

--- a/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
@@ -69,8 +69,8 @@ const TypeOfConsequence = (props: ConsequenceTypePageProps): ReactElement => {
                                     href={
                                         returnToTemplateOverview
                                             ? `${queryParams["return"] as string}/${pageState.disruptionId || ""}${
-                                                isTemplate ? "?template=true" : ""
-                                            }`
+                                                  isTemplate ? "?template=true" : ""
+                                              }`
                                             : `${queryParams["return"] as string}/${pageState.disruptionId || ""}`
                                     }
                                     className="govuk-button mt-8 ml-1 govuk-button--secondary"

--- a/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
@@ -68,10 +68,10 @@ const TypeOfConsequence = (props: ConsequenceTypePageProps): ReactElement => {
                                     role="button"
                                     href={
                                         returnToTemplateOverview
-                                            ? (queryParams["return"] as string)
-                                            : `${queryParams["return"] as string}/${pageState.disruptionId || ""}${
-                                                  isTemplate ? "?template=true" : ""
-                                              }`
+                                            ? `${queryParams["return"] as string}/${pageState.disruptionId || ""}${
+                                                isTemplate ? "?template=true" : ""
+                                            }`
+                                            : `${queryParams["return"] as string}/${pageState.disruptionId || ""}`
                                     }
                                     className="govuk-button mt-8 ml-1 govuk-button--secondary"
                                 >

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -122,7 +122,5 @@ export const showCancelButton = (queryParams: ParsedUrlQuery) => {
 };
 
 export const returnTemplateOverview = (queryParams: ParsedUrlQuery) => {
-    return (
-        queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH) && queryParams["return"]?.includes("template=true")
-    );
+    return queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH) && queryParams["template"]?.includes("true");
 };


### PR DESCRIPTION
The issue was that if you go to an existing template and attempt to change something it would error.

The fix is to check whether the template is in edit or create flow and then redirect accordingly.

Test the create flows and the edit flows.

Also fixes Error page found when changing the selected consequence during creating a new template