### PR TITLE
feat: consequence dropdown improvement

### DIFF
--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -45,6 +45,8 @@ import {
     getStateUpdater,
     getStopLabel,
     getStopValue,
+    isSelectedServiceInDropdown,
+    isSelectedStopInDropdown,
     returnTemplateOverview,
     showCancelButton,
     sortAndFilterStops,
@@ -451,7 +453,9 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                             initialErrors={pageState.errors}
                             placeholder="Select services"
                             getOptionLabel={getServiceLabel}
-                            options={servicesRecords}
+                            options={servicesRecords.filter(
+                                (service) => !isSelectedServiceInDropdown(service, pageState.inputs.services ?? []),
+                            )}
                             handleChange={handleServiceChange}
                             tableData={pageState?.inputs?.services}
                             getRows={getServiceRows}
@@ -480,7 +484,9 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                             hint="Stops"
                             displaySize="l"
                             inputId="stops"
-                            options={stopOptions}
+                            options={stopOptions.filter(
+                                (stop) => !isSelectedStopInDropdown(stop, pageState.inputs.stops ?? []),
+                            )}
                             inputValue={stopsSearchInput}
                             setSearchInput={setStopsSearchInput}
                         />

--- a/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
@@ -37,6 +37,7 @@ import {
     getStateUpdater,
     getStopLabel,
     getStopValue,
+    isSelectedStopInDropdown,
     returnTemplateOverview,
     showCancelButton,
 } from "../../../utils/formUtils";
@@ -241,7 +242,9 @@ const CreateConsequenceStops = (props: CreateConsequenceStopsProps): ReactElemen
                             inputValue={searchInput}
                             setSearchInput={setSearchInput}
                             isClearable
-                            options={stopOptions}
+                            options={stopOptions.filter(
+                                (stop) => !isSelectedStopInDropdown(stop, pageState.inputs.stops ?? []),
+                            )}
                             onBlur={() => {
                                 setChangePlaceHolder(false);
                             }}

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -1,4 +1,4 @@
-import { ConsequenceOperators, Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
+import { ConsequenceOperators, Service, Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
 import { getDate } from "@create-disruptions-data/shared-ts/utils/dates";
 import dayjs from "dayjs";
 import { SetStateAction } from "react";
@@ -124,3 +124,8 @@ export const showCancelButton = (queryParams: ParsedUrlQuery) => {
 export const returnTemplateOverview = (queryParams: ParsedUrlQuery) => {
     return queryParams["return"]?.includes(DISRUPTION_DETAIL_PAGE_PATH) && queryParams["template"]?.includes("true");
 };
+export const isSelectedStopInDropdown = (stop: Stop, selectedStops: Stop[]) =>
+    selectedStops.find((selectedStop) => selectedStop.atcoCode === stop.atcoCode);
+
+export const isSelectedServiceInDropdown = (service: Service, selectedService: Service[]) =>
+    selectedService.find((selectedService) => selectedService.id === service.id);


### PR DESCRIPTION
Improvement to the services and stops consequences pages. Modified the behaviour of the services and stops dropdowns so that if a service or stop is selected it will no longer appear as an option on the dropdown.