### PR TITLE
feat: Add "Create disruption" functionality to draft templates

### DIFF
--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -393,16 +393,18 @@ const DisruptionDetail = ({
                     <ErrorSummary errors={errors} />
                     <div className="govuk-form-group">
                         <h1 className="govuk-heading-xl">{title}</h1>
-                        {disruption.template && disruption.publishStatus === PublishStatus.published && (
-                            <button
-                                key="create-disruption-from-template"
-                                className="govuk-button"
-                                data-module="govuk-button"
-                                formAction={`/api/duplicate-disruption?templateId=${disruption.disruptionId}&template=true`}
-                            >
-                                Create disruption
-                            </button>
-                        )}
+                        {disruption.template &&
+                            (disruption.publishStatus === PublishStatus.published ||
+                                disruption.publishStatus === PublishStatus.draft) && (
+                                <button
+                                    key="create-disruption-from-template"
+                                    className="govuk-button"
+                                    data-module="govuk-button"
+                                    formAction={`/api/duplicate-disruption?templateId=${disruption.disruptionId}&template=true`}
+                                >
+                                    Create disruption
+                                </button>
+                            )}
                         {!disruption.template && (
                             <Link
                                 className="govuk-link"

--- a/site/pages/disruption-detail/disruption-detail.test.tsx
+++ b/site/pages/disruption-detail/disruption-detail.test.tsx
@@ -270,10 +270,41 @@ describe("pages", () => {
             expect(tree).toMatchSnapshot();
         });
 
-        it("should render correctly with inputs and create new disruption button for templates", () => {
+        it("should render correctly with inputs and create new disruption button for published templates", () => {
             const { queryByText, getAllByRole, unmount } = render(
                 <DisruptionDetail
                     disruption={{ ...previousDisruptionInformation, template: true }}
+                    redirect={"/view-all-templates"}
+                    errors={[]}
+                    canPublish={true}
+                />,
+            );
+
+            const createDisruptionButton = queryByText("Create disruption", {
+                selector: "button",
+            });
+
+            const closeButton = getAllByRole("button", { name: "Close and Return" });
+
+            const deleteTemplateButton = queryByText("Delete template", {
+                selector: "button",
+            });
+
+            expect(createDisruptionButton).toBeTruthy();
+            expect(closeButton).toBeTruthy();
+            expect(deleteTemplateButton).toBeTruthy();
+
+            unmount();
+        });
+
+        it("should render correctly with inputs and create new disruption button for draft templates", () => {
+            const { queryByText, getAllByRole, unmount } = render(
+                <DisruptionDetail
+                    disruption={{
+                        ...previousDisruptionInformation,
+                        template: true,
+                        publishStatus: PublishStatus.draft,
+                    }}
                     redirect={"/view-all-templates"}
                     errors={[]}
                     canPublish={true}


### PR DESCRIPTION
Go to view all templates
Click a draft template (or create one)
You should see the create disruption button click on it and go through the flow or click to the main dashboard
See if the disruption appears as draft/published