### PR TITLE
fix: Adding error messages for templates and disruptions not found

### DIFF
--- a/site/constants/index.ts
+++ b/site/constants/index.ts
@@ -273,6 +273,7 @@ export const CREATE_SOCIAL_MEDIA_POST_PAGE_PATH = "/create-social-media-post";
 export const SYSADMIN_MANAGE_ORGANISATIONS_PAGE_PATH = "/sysadmin/manage-organisations";
 export const SYSADMIN_ADD_USERS_PAGE_PATH = "/sysadmin/users";
 export const SYSADMIN_ADD_ORG_PAGE_PATH = "/sysadmin/org";
+export const DISRUPTION_NOT_FOUND_ERROR_PAGE = "/disruption-not-found";
 
 // COOKIES
 export const COOKIES_DISRUPTION_ERRORS = "cdd-disruption-errors";

--- a/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-network/[disruptionId]/[consequenceIndex].page.tsx
@@ -19,13 +19,14 @@ import {
     COOKIES_CONSEQUENCE_NETWORK_ERRORS,
     CREATE_CONSEQUENCE_NETWORK_PATH,
     DISRUPTION_DETAIL_PAGE_PATH,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
     DISRUPTION_SEVERITIES,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     VEHICLE_MODES,
 } from "../../../constants";
 import { getDisruptionById } from "../../../data/dynamo";
 import { CreateConsequenceProps, PageState } from "../../../interfaces";
-import { isNetworkConsequence } from "../../../utils";
+import { isNetworkConsequence, redirectTo } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSession } from "../../../utils/apiUtils/auth";
 import { getStateUpdater, returnTemplateOverview, showCancelButton } from "../../../utils/formUtils";
@@ -240,7 +241,10 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     );
 
     if (!disruption) {
-        throw new Error("No disruption found for network consequence page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
 
     const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -338,7 +338,7 @@ export const getServerSideProps = async (
         }
         return;
     }
-    
+
     const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;
 
     const consequence = disruption?.consequences?.find((c) => c.consequenceIndex === index);

--- a/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-operator/[disruptionId]/[consequenceIndex].page.tsx
@@ -21,6 +21,7 @@ import {
     COOKIES_CONSEQUENCE_OPERATOR_ERRORS,
     CREATE_CONSEQUENCE_OPERATOR_PATH,
     DISRUPTION_DETAIL_PAGE_PATH,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
     DISRUPTION_SEVERITIES,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     VEHICLE_MODES,
@@ -30,7 +31,7 @@ import { fetchOperators } from "../../../data/refDataApi";
 import { CreateConsequenceProps, PageState } from "../../../interfaces";
 import { Operator } from "../../../schemas/consequence.schema";
 import { ModeType } from "../../../schemas/organisation.schema";
-import { isOperatorConsequence } from "../../../utils";
+import { isOperatorConsequence, redirectTo } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";
 import {
@@ -332,9 +333,12 @@ export const getServerSideProps = async (
     );
 
     if (!disruption) {
-        throw new Error("No disruption found for operator consequence page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
-
+    
     const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;
 
     const consequence = disruption?.consequences?.find((c) => c.consequenceIndex === index);

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -32,12 +32,13 @@ import {
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     CREATE_CONSEQUENCE_SERVICES_PATH,
     DISRUPTION_DETAIL_PAGE_PATH,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
 } from "../../../constants";
 import { getDisruptionById } from "../../../data/dynamo";
 import { fetchServiceRoutes, fetchServiceStops, fetchServices } from "../../../data/refDataApi";
 import { CreateConsequenceProps, PageState } from "../../../interfaces";
 import { Routes } from "../../../schemas/consequence.schema";
-import { flattenZodErrors, getServiceLabel, isServicesConsequence, sortServices } from "../../../utils";
+import { flattenZodErrors, getServiceLabel, isServicesConsequence, redirectTo, sortServices } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";
 import {
@@ -689,7 +690,10 @@ export const getServerSideProps = async (
     );
 
     if (!disruption) {
-        throw new Error("No disruption found for operator consequence page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
 
     const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;

--- a/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
@@ -26,11 +26,12 @@ import {
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
     CREATE_CONSEQUENCE_STOPS_PATH,
     DISRUPTION_DETAIL_PAGE_PATH,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
 } from "../../../constants";
 import { getDisruptionById } from "../../../data/dynamo";
 import { fetchStops } from "../../../data/refDataApi";
 import { CreateConsequenceProps, PageState } from "../../../interfaces";
-import { flattenZodErrors, isStopsConsequence } from "../../../utils";
+import { flattenZodErrors, isStopsConsequence, redirectTo } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";
 import {
@@ -420,7 +421,10 @@ export const getServerSideProps = async (
     );
 
     if (!disruption) {
-        throw new Error("No disruption found for operator consequence page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
 
     const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;

--- a/site/pages/disruption-detail/[disruptionId].page.tsx
+++ b/site/pages/disruption-detail/[disruptionId].page.tsx
@@ -19,6 +19,7 @@ import {
     CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
     DISRUPTION_DETAIL_PAGE_PATH,
     DISRUPTION_HISTORY_PAGE_PATH,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
     TYPE_OF_CONSEQUENCE_PAGE_PATH,
 } from "../../constants";
 import { getDisruptionById } from "../../data/dynamo";
@@ -26,7 +27,7 @@ import { getItem } from "../../data/s3";
 import { ErrorInfo } from "../../interfaces";
 import { FullDisruption } from "../../schemas/disruption.schema";
 import { SocialMediaPost, SocialMediaPostTransformed } from "../../schemas/social-media.schema";
-import { getLargestConsequenceIndex, splitCamelCaseToString } from "../../utils";
+import { getLargestConsequenceIndex, redirectTo, splitCamelCaseToString } from "../../utils";
 import { destroyCookieOnResponseObject, setCookieOnResponseObject } from "../../utils/apiUtils";
 import { canPublish, getSession } from "../../utils/apiUtils/auth";
 import { formatTime, getEndingOnDateText } from "../../utils/dates";
@@ -864,7 +865,10 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     }
 
     if (!disruption) {
-        throw new Error("Disruption not found for disruption detail page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
 
     let socialMediaWithImageLinks: SocialMediaPost[] = [];

--- a/site/pages/disruption-not-found.page.tsx
+++ b/site/pages/disruption-not-found.page.tsx
@@ -2,7 +2,7 @@ import { NextPageContext } from "next";
 import Link from "next/link";
 import { ReactElement } from "react";
 import { TwoThirdsLayout } from "../components/layout/Layout";
-import { DASHBOARD_PAGE_PATH, VIEW_ALL_TEMPLATES_PAGE_PATH } from "../constants";
+import { DASHBOARD_PAGE_PATH } from "../constants";
 import { getSession } from "../utils/apiUtils/auth";
 
 const title = "Disruption Not Found - Create Transport Disruption Data Service";
@@ -34,7 +34,7 @@ const DisruptionNotFound = ({ isTemplate }: { isTemplate: boolean }): ReactEleme
     </TwoThirdsLayout>
 );
 
-export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: { isTemplate: boolean } } | void> => {
+export const getServerSideProps = (ctx: NextPageContext): { props: { isTemplate: boolean } } | void => {
     if (!ctx.req) {
         throw new Error("No context request");
     }

--- a/site/pages/disruption-not-found.page.tsx
+++ b/site/pages/disruption-not-found.page.tsx
@@ -1,0 +1,55 @@
+import { NextPageContext } from "next";
+import Link from "next/link";
+import { ReactElement } from "react";
+import { TwoThirdsLayout } from "../components/layout/Layout";
+import { DASHBOARD_PAGE_PATH, VIEW_ALL_TEMPLATES_PAGE_PATH } from "../constants";
+import { getSession } from "../utils/apiUtils/auth";
+
+const title = "Disruption Not Found - Create Transport Disruption Data Service";
+const description = "Disruption Not Found page for the Create Transport Disruption Data Service";
+
+const DisruptionNotFound = ({ isTemplate }: { isTemplate: boolean }): ReactElement => (
+    <TwoThirdsLayout title={title} description={description}>
+        <div>
+            <h1 className="govuk-heading-l">{`${isTemplate ? "Template" : "Disruption"} not found`}</h1>
+            <p className="govuk-body">
+                {" "}
+                <Link className="govuk-link" id="contact-link" href={"/contact"}>
+                    Contact
+                </Link>{" "}
+                us for assistance.
+            </p>
+        </div>
+
+        <br />
+        <Link
+            href={DASHBOARD_PAGE_PATH}
+            role="button"
+            draggable="false"
+            className="govuk-button"
+            data-module="govuk-button"
+        >
+            Back to dashboard
+        </Link>
+    </TwoThirdsLayout>
+);
+
+export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: { isTemplate: boolean } } | void> => {
+    if (!ctx.req) {
+        throw new Error("No context request");
+    }
+
+    const session = getSession(ctx.req);
+
+    if (!session) {
+        throw new Error("No session found");
+    }
+
+    return {
+        props: {
+            isTemplate: !!ctx.query?.template,
+        },
+    };
+};
+
+export default DisruptionNotFound;

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -21,13 +21,14 @@ import {
     CREATE_SOCIAL_MEDIA_POST_PAGE_PATH,
     DASHBOARD_PAGE_PATH,
     COOKIES_REVIEW_DISRUPTION_REFERER,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
 } from "../../constants";
 import { getDisruptionById } from "../../data/dynamo";
 import { getItem } from "../../data/s3";
 import { ErrorInfo } from "../../interfaces";
 import { FullDisruption } from "../../schemas/disruption.schema";
 import { SocialMediaPost, SocialMediaPostTransformed } from "../../schemas/social-media.schema";
-import { getLargestConsequenceIndex, splitCamelCaseToString } from "../../utils";
+import { getLargestConsequenceIndex, redirectTo, splitCamelCaseToString } from "../../utils";
 import { destroyCookieOnResponseObject, setCookieOnResponseObject } from "../../utils/apiUtils";
 import { canPublish, getSession } from "../../utils/apiUtils/auth";
 import { formatTime, getEndingOnDateText } from "../../utils/dates";
@@ -761,6 +762,14 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         session.orgId,
         !!ctx.query?.template,
     );
+
+    if (!disruption) {
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
+    }
+
     const cookies = parseCookies(ctx);
     const errorCookie = cookies[COOKIES_REVIEW_DISRUPTION_ERRORS];
 

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -763,6 +763,13 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         !!ctx.query?.template,
     );
 
+    if (!disruption) {
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
+    }
+
     const cookies = parseCookies(ctx);
     const errorCookie = cookies[COOKIES_REVIEW_DISRUPTION_ERRORS];
 
@@ -801,13 +808,6 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     let errors: ErrorInfo[] = [];
     if (errorCookie) {
         errors = JSON.parse(errorCookie) as ErrorInfo[];
-    }
-
-    if (!disruption) {
-        if (ctx.res) {
-            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
-        }
-        return;
     }
 
     if (ctx.res) destroyCookieOnResponseObject(COOKIES_REVIEW_DISRUPTION_ERRORS, ctx.res);

--- a/site/pages/review-disruption/[disruptionId].page.tsx
+++ b/site/pages/review-disruption/[disruptionId].page.tsx
@@ -763,13 +763,6 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         !!ctx.query?.template,
     );
 
-    if (!disruption) {
-        if (ctx.res) {
-            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
-        }
-        return;
-    }
-
     const cookies = parseCookies(ctx);
     const errorCookie = cookies[COOKIES_REVIEW_DISRUPTION_ERRORS];
 
@@ -811,7 +804,10 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     }
 
     if (!disruption) {
-        throw new Error("Disruption not found for review page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
 
     if (ctx.res) destroyCookieOnResponseObject(COOKIES_REVIEW_DISRUPTION_ERRORS, ctx.res);

--- a/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/type-of-consequence/[disruptionId]/[consequenceIndex].page.tsx
@@ -8,10 +8,15 @@ import CsrfForm from "../../../components/form/CsrfForm";
 import ErrorSummary from "../../../components/form/ErrorSummary";
 import Radios from "../../../components/form/Radios";
 import { TwoThirdsLayout } from "../../../components/layout/Layout";
-import { COOKIES_CONSEQUENCE_TYPE_ERRORS, CONSEQUENCE_TYPES } from "../../../constants/index";
+import {
+    COOKIES_CONSEQUENCE_TYPE_ERRORS,
+    CONSEQUENCE_TYPES,
+    DISRUPTION_NOT_FOUND_ERROR_PAGE,
+} from "../../../constants/index";
 import { getDisruptionById } from "../../../data/dynamo";
 import { PageState } from "../../../interfaces/index";
 import { ConsequenceType, typeOfConsequenceSchema } from "../../../schemas/type-of-consequence.schema";
+import { redirectTo } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSession } from "../../../utils/apiUtils/auth";
 import { getStateUpdater, returnTemplateOverview, showCancelButton } from "../../../utils/formUtils";
@@ -113,11 +118,15 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         session.orgId,
         !!ctx.query.template,
     );
-    const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;
 
     if (!disruption) {
-        throw new Error("Disruption not found for consequence type page");
+        if (ctx.res) {
+            redirectTo(ctx.res, `${DISRUPTION_NOT_FOUND_ERROR_PAGE}${!!ctx.query?.template ? "?template=true" : ""}`);
+        }
+        return;
     }
+
+    const index = ctx.query.consequenceIndex ? Number(ctx.query.consequenceIndex) : 0;
 
     if (ctx.res) destroyCookieOnResponseObject(COOKIES_CONSEQUENCE_TYPE_ERRORS, ctx.res);
 


### PR DESCRIPTION
View a template or disruption, delete it press back arrow on the browser.

Chris has stated he wants both to navigate back to the dashboard. Design of page has been confirmed with him too.