### PR TITLE
changes to retrieve disruption stops and routes for services in an organisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28354,7 +28354,25 @@
             "name": "@create-disruptions-data/shared-ts",
             "version": "0.1.0",
             "dependencies": {
-                "dayjs": "^1.11.7"
+                "dayjs": "^1.11.7",
+                "node-fetch": "^3.3.2"
+            }
+        },
+        "shared-ts/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "site": {

--- a/packages/organisations-api/get-organisation-stops/index.ts
+++ b/packages/organisations-api/get-organisation-stops/index.ts
@@ -163,7 +163,7 @@ const getOrganisationStops = async (orgId: string) => {
         return { stops, services: routesForMaps };
     } catch (e) {
         if (e instanceof Error) {
-            logger.error(e);
+            logger.error(`Error occured while getting stops and services for an organisation: ${orgId} - error: `, e);
 
             throw e;
         }
@@ -180,7 +180,7 @@ export const main = async (event: APIGatewayEvent): Promise<{ statusCode: number
         logger.options.meta = {
             id: randomUUID(),
         };
-        logger.info("Starting get organisation stops data...");
+        logger.info("Starting get organisation stops data and routes for services data...");
 
         const { ORGANISATIONS_TABLE_NAME: orgTableName } = process.env;
 
@@ -196,7 +196,7 @@ export const main = async (event: APIGatewayEvent): Promise<{ statusCode: number
 
         const stopsAndServicesMapData = await getOrganisationStops(orgId);
 
-        logger.info("Successfully retrieved organisations DynamoDB...");
+        logger.info(`Successfully retrieved organisation: ${orgId}'s stops from DynamoDB...`);
 
         return {
             statusCode: 200,

--- a/packages/organisations-api/get-organisation-stops/index.ts
+++ b/packages/organisations-api/get-organisation-stops/index.ts
@@ -1,12 +1,43 @@
-import { getImpactedStopsInOrganisation } from "@create-disruptions-data/shared-ts/utils/dynamo";
+import { Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
+import {
+    getImpactedServicesInOrganisation,
+    getImpactedStopsInOrganisation,
+} from "@create-disruptions-data/shared-ts/utils/dynamo";
+import { fetchServiceRoutes } from "@create-disruptions-data/shared-ts/utils/refDataApi";
 import { APIGatewayEvent } from "aws-lambda";
 import * as logger from "lambda-log";
 import { randomUUID } from "crypto";
 
+const fetchRoute = (routesData: Partial<Stop>[]) => {
+    const routes =
+        routesData.map((route) => (route.latitude && route.longitude ? [route.latitude, route.longitude] : [])) ?? [];
+
+    return routes;
+};
+
 const getOrganisationStops = async (orgId: string) => {
     try {
-        const orgList = await getImpactedStopsInOrganisation(orgId, logger);
-        return orgList || [];
+        const [orgList, servicesList] = await Promise.all([
+            getImpactedStopsInOrganisation(orgId, logger),
+            getImpactedServicesInOrganisation(orgId, logger),
+        ]);
+
+        const routesForMaps: number[][][] = [];
+        await Promise.all(
+            servicesList.map(async (service) => {
+                const routesData = await fetchServiceRoutes(service.id, logger);
+
+                const [inboundRoute, outboundRoute] = await Promise.all([
+                    fetchRoute(routesData?.inbound ?? []),
+                    fetchRoute(routesData?.outbound ?? []),
+                ]);
+
+                routesForMaps.push(inboundRoute);
+                routesForMaps.push(outboundRoute);
+            }),
+        );
+
+        return { stops: orgList, services: routesForMaps };
     } catch (e) {
         if (e instanceof Error) {
             logger.error(e);
@@ -40,13 +71,13 @@ export const main = async (event: APIGatewayEvent): Promise<{ statusCode: number
             throw new Error("An organisation ID must be provided");
         }
 
-        const stops = await getOrganisationStops(orgId);
+        const stopsAndServicesMapData = await getOrganisationStops(orgId);
 
         logger.info("Successfully retrieved organisations DynamoDB...");
 
         return {
             statusCode: 200,
-            body: JSON.stringify(stops),
+            body: JSON.stringify(stopsAndServicesMapData),
         };
     } catch (e) {
         if (e instanceof Error) {

--- a/packages/organisations-api/get-organisation-stops/index.ts
+++ b/packages/organisations-api/get-organisation-stops/index.ts
@@ -1,0 +1,60 @@
+import { getImpactedStopsInOrganisation } from "@create-disruptions-data/shared-ts/utils/dynamo";
+import { APIGatewayEvent } from "aws-lambda";
+import * as logger from "lambda-log";
+import { randomUUID } from "crypto";
+
+const getOrganisationStops = async (orgId: string) => {
+    try {
+        const orgList = await getImpactedStopsInOrganisation(orgId, logger);
+        return orgList || [];
+    } catch (e) {
+        if (e instanceof Error) {
+            logger.error(e);
+
+            throw e;
+        }
+
+        throw e;
+    }
+};
+
+export const main = async (event: APIGatewayEvent): Promise<{ statusCode: number; body: string }> => {
+    try {
+        logger.options.dev = process.env.NODE_ENV !== "production";
+        logger.options.debug = process.env.ENABLE_DEBUG_LOGS === "true" || process.env.NODE_ENV !== "production";
+
+        logger.options.meta = {
+            id: randomUUID(),
+        };
+        logger.info("Starting get organisation stops data...");
+
+        const { ORGANISATIONS_TABLE_NAME: orgTableName } = process.env;
+
+        if (!orgTableName) {
+            throw new Error("Dynamo table names not set");
+        }
+
+        const orgId = event?.pathParameters?.id;
+
+        if (!orgId) {
+            throw new Error("An organisation ID must be provided");
+        }
+
+        const stops = await getOrganisationStops(orgId);
+
+        logger.info("Successfully retrieved organisations DynamoDB...");
+
+        return {
+            statusCode: 200,
+            body: JSON.stringify(stops),
+        };
+    } catch (e) {
+        if (e instanceof Error) {
+            logger.error(e);
+
+            throw e;
+        }
+
+        throw e;
+    }
+};

--- a/packages/organisations-api/get-organisation-stops/index.ts
+++ b/packages/organisations-api/get-organisation-stops/index.ts
@@ -102,8 +102,8 @@ const getOrganisationStops = async (orgId: string) => {
                     fetchRoute(routesData?.outbound ?? []),
                 ]);
 
-                routesForMaps.push(inboundRoute);
-                routesForMaps.push(outboundRoute);
+                if (inboundRoute && inboundRoute.length > 0) routesForMaps.push(inboundRoute);
+                if (outboundRoute && outboundRoute.length > 0) routesForMaps.push(outboundRoute);
             }),
         );
 

--- a/packages/organisations-api/get-organisation-stops/index.ts
+++ b/packages/organisations-api/get-organisation-stops/index.ts
@@ -9,7 +9,7 @@ import { randomUUID } from "crypto";
 
 const fetchRoute = (routesData: Partial<Stop>[]) => {
     const routes =
-        routesData.map((route) => (route.latitude && route.longitude ? [route.latitude, route.longitude] : [])) ?? [];
+        routesData.map((route) => (route.latitude && route.longitude ? [route.longitude, route.latitude] : [])) ?? [];
 
     return routes;
 };
@@ -19,7 +19,7 @@ const getMapData = (stops: Stop[], uniqueStopIds: Set<string>) => {
         .map((stop) => {
             if (!uniqueStopIds.has(stop.atcoCode)) {
                 uniqueStopIds.add(stop.atcoCode);
-                return [stop.latitude, stop.longitude];
+                return [stop.longitude, stop.latitude];
             } else {
                 return null;
             }

--- a/shared-ts/disruptionTypes.ts
+++ b/shared-ts/disruptionTypes.ts
@@ -27,3 +27,10 @@ export type NetworkConsequence = z.infer<typeof networkConsequenceSchema>;
 export type OperatorConsequence = z.infer<typeof operatorConsequenceSchema>;
 export type StopsConsequence = z.infer<typeof stopsConsequenceSchema>;
 export type ServicesConsequence = z.infer<typeof servicesConsequenceSchema>;
+
+export const routesSchema = z.object({
+    inbound: z.array(stopSchema.partial()),
+    outbound: z.array(stopSchema.partial()),
+});
+
+export type Routes = z.infer<typeof routesSchema>;

--- a/shared-ts/disruptionTypes.ts
+++ b/shared-ts/disruptionTypes.ts
@@ -34,3 +34,20 @@ export const routesSchema = z.object({
 });
 
 export type Routes = z.infer<typeof routesSchema>;
+
+export type ServiceGeoJSON = {
+    type: string;
+    geometry: {
+        type: string;
+        coordinates: number[][];
+    };
+    properties: {
+        service_line_id: string;
+        destination: string;
+        origin: string;
+        service_line_name: string;
+        service_noc_code: string;
+        service_operator: string;
+        service_code: string;
+    };
+};

--- a/shared-ts/organisationTypes.ts
+++ b/shared-ts/organisationTypes.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { stopSchema } from "./disruptionTypes.zod";
+import { serviceSchema, stopSchema } from "./disruptionTypes.zod";
 
 export const organisationSchema = z
     .object({
@@ -27,7 +27,11 @@ export const statisticSchema = z.object({
 export const organisationSchemaWithStats = organisationSchema.and(z.object({ stats: statisticSchema }));
 
 export const organisationStops = z.object({
-    stops: z.array(stopSchema),
+    stops: z.array(z.unknown()),
+});
+
+export const organisationServices = z.object({
+    services: z.array(z.unknown()),
 });
 
 export type Organisation = z.infer<typeof organisationSchema>;

--- a/shared-ts/organisationTypes.ts
+++ b/shared-ts/organisationTypes.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { stopSchema } from "./disruptionTypes.zod";
 
 export const organisationSchema = z
     .object({
@@ -24,6 +25,10 @@ export const statisticSchema = z.object({
 });
 
 export const organisationSchemaWithStats = organisationSchema.and(z.object({ stats: statisticSchema }));
+
+export const organisationStops = z.object({
+    stops: z.array(stopSchema),
+});
 
 export type Organisation = z.infer<typeof organisationSchema>;
 export type OrganisationWithStats = z.infer<typeof organisationSchemaWithStats>;

--- a/shared-ts/organisationTypes.ts
+++ b/shared-ts/organisationTypes.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { serviceSchema, stopSchema } from "./disruptionTypes.zod";
 
 export const organisationSchema = z
     .object({

--- a/shared-ts/organisationTypes.ts
+++ b/shared-ts/organisationTypes.ts
@@ -25,13 +25,5 @@ export const statisticSchema = z.object({
 
 export const organisationSchemaWithStats = organisationSchema.and(z.object({ stats: statisticSchema }));
 
-export const organisationStops = z.object({
-    stops: z.array(z.unknown()),
-});
-
-export const organisationServices = z.object({
-    services: z.array(z.unknown()),
-});
-
 export type Organisation = z.infer<typeof organisationSchema>;
 export type OrganisationWithStats = z.infer<typeof organisationSchemaWithStats>;

--- a/shared-ts/package.json
+++ b/shared-ts/package.json
@@ -6,6 +6,7 @@
         "generate-zod": "npx ts-to-zod ./siriTypes.ts ./siriTypes.zod.ts"
     },
     "dependencies": {
-        "dayjs": "^1.11.7"
+        "dayjs": "^1.11.7",
+        "node-fetch": "^3.3.2"
     }
 }

--- a/shared-ts/utils/dynamo.ts
+++ b/shared-ts/utils/dynamo.ts
@@ -291,7 +291,7 @@ export const getImpactedStopsInOrganisation = async (orgId: string, logger: Logg
                     }
                 });
             } catch (error) {
-                return null; // Return null for objects that fail validation
+                logger.debug(`Error while parsing stops record. One of more stops record will be ignored`);
             }
         });
 
@@ -338,7 +338,7 @@ export const getImpactedServicesInOrganisation = async (orgId: string, logger: L
                     }
                 });
             } catch (error) {
-                return null; // Return null for objects that fail validation
+                logger.debug(`Error while parsing service records. One of more services record will be ignored`);
             }
         });
 

--- a/shared-ts/utils/index.ts
+++ b/shared-ts/utils/index.ts
@@ -1,3 +1,10 @@
 export const notEmpty = <T>(value: T | null | undefined): value is T => {
     return value !== null && value !== undefined;
 };
+
+export type Logger = {
+    info: (message: string) => void;
+    error: (message: string | Error) => void;
+    warn: (message: string) => void;
+    debug: (message: string) => void;
+};

--- a/shared-ts/utils/refDataApi.ts
+++ b/shared-ts/utils/refDataApi.ts
@@ -1,0 +1,25 @@
+import fetch from "node-fetch";
+import { routesSchema } from "../disruptionTypes";
+import { Logger } from ".";
+
+export const fetchServiceRoutes = async (serviceId: number, logger: Logger) => {
+    logger.debug(`Retrieving routes for service: ${serviceId}`);
+
+    if (!process.env.API_BASE_URL) {
+        logger.error("Reference data service URL is not set as an environment variable");
+        throw Error;
+    }
+    const searchApiUrl = `${process.env.API_BASE_URL}/services/${serviceId}/routes`;
+
+    const res = await fetch(searchApiUrl, {
+        method: "GET",
+    });
+
+    const parseResult = routesSchema.safeParse(await res.json());
+
+    if (!parseResult.success) {
+        return null;
+    }
+
+    return parseResult.data;
+};

--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -1,4 +1,4 @@
-import { Service, ServicesConsequence, Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
+import { Routes, Service, ServicesConsequence, Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
 import { servicesConsequenceSchema, stopSchema } from "@create-disruptions-data/shared-ts/disruptionTypes.zod";
 import { Datasource, Modes, VehicleMode } from "@create-disruptions-data/shared-ts/enums";
 import { LoadingBox } from "@govuk-react/loading-box";
@@ -23,7 +23,6 @@ import Markers from "./Markers";
 import { fetchServicesByStops, fetchStops } from "../../data/refDataApi";
 import { LargePolygonError, NoStopsError } from "../../errors";
 import { PageState } from "../../interfaces";
-import { Routes } from "../../schemas/consequence.schema";
 import { flattenZodErrors } from "../../utils";
 import { filterServices, getStopType, sortAndFilterStops, sortStops } from "../../utils/formUtils";
 import { warningMessageText } from "../../utils/mapUtils";

--- a/site/data/refDataApi.ts
+++ b/site/data/refDataApi.ts
@@ -1,3 +1,4 @@
+import { routesSchema } from "@create-disruptions-data/shared-ts/disruptionTypes";
 import { serviceSchema, stopSchema } from "@create-disruptions-data/shared-ts/disruptionTypes.zod";
 import { Datasource, Modes } from "@create-disruptions-data/shared-ts/enums";
 import { makeFilteredArraySchema } from "@create-disruptions-data/shared-ts/utils/zod";
@@ -5,7 +6,7 @@ import { Position } from "geojson";
 import { z } from "zod";
 import { API_BASE_URL } from "../constants";
 import { LargePolygonError, NoStopsError } from "../errors";
-import { operatorSchema, routesSchema, serviceByStopSchema } from "../schemas/consequence.schema";
+import { operatorSchema, serviceByStopSchema } from "../schemas/consequence.schema";
 
 interface FetchStopsInput {
     adminAreaCodes: string[];

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -1,4 +1,4 @@
-import { Service, ServicesConsequence, Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
+import { Routes, Service, ServicesConsequence, Stop } from "@create-disruptions-data/shared-ts/disruptionTypes";
 import {
     serviceSchema,
     servicesConsequenceSchema,
@@ -37,7 +37,6 @@ import {
 import { getDisruptionById } from "../../../data/dynamo";
 import { fetchServiceRoutes, fetchServiceStops, fetchServices } from "../../../data/refDataApi";
 import { CreateConsequenceProps, PageState } from "../../../interfaces";
-import { Routes } from "../../../schemas/consequence.schema";
 import { flattenZodErrors, getServiceLabel, isServicesConsequence, redirectTo, sortServices } from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";

--- a/site/schemas/consequence.schema.ts
+++ b/site/schemas/consequence.schema.ts
@@ -1,16 +1,9 @@
-import { serviceSchema, stopSchema } from "@create-disruptions-data/shared-ts/disruptionTypes.zod";
+import { serviceSchema } from "@create-disruptions-data/shared-ts/disruptionTypes.zod";
 import { z } from "zod";
 
 export const duplicateConsequenceSchema = z.object({
     disruptionId: z.string().uuid(),
 });
-
-export const routesSchema = z.object({
-    inbound: z.array(stopSchema.partial()),
-    outbound: z.array(stopSchema.partial()),
-});
-
-export type Routes = z.infer<typeof routesSchema>;
 
 export const serviceByStopSchema = serviceSchema.and(
     z.object({

--- a/stacks/services/APIGateway.ts
+++ b/stacks/services/APIGateway.ts
@@ -14,6 +14,10 @@ export const createSiriApi = (stack: Stack, siriSXBucket: Bucket, hostedZone: IH
     const subDomain = ["test", "preprod", "prod"].includes(stack.stage) ? "api" : `api.${stack.stage}`;
     const { organisationsTableV2: organisationsTable, disruptionsTable } = use(DynamoDBStack);
 
+    const apiUrl = !["preprod", "prod"].includes(stack.stage)
+        ? "https://api.test.ref-data.dft-create-data.com/v1"
+        : `https://api.${stack.stage}.ref-data.dft-create-data.com/v1`;
+
     const apiGateway = new ApiGatewayV1Api(stack, "cdd-siri-sx-api", {
         customDomain: {
             domainName: `${subDomain}.${hostedZone.zoneName}`,
@@ -34,6 +38,7 @@ export const createSiriApi = (stack: Stack, siriSXBucket: Bucket, hostedZone: IH
                 environment: {
                     ORGANISATIONS_TABLE_NAME: organisationsTable.tableName,
                     DISRUPTIONS_TABLE_NAME: disruptionsTable.tableName,
+                    API_BASE_URL: apiUrl,
                 },
                 permissions: ["dynamodb:Scan", "dynamodb:Query"],
             },


### PR DESCRIPTION
Testing instruction:

Run "npm run dev" from root and then run the below command to invoke and test the api. Update values according to your local env setup

```curl -X GET -H "x-api-key: <your-api-key>" https://<api-gateway-endpoint>/<sst-stage-name>/organisations/<org-id>/impacted/stops```

example:

```curl -X GET -H "x-api-key: <api-key>" https://taejenagw7.execute-api.eu-west-2.amazonaws.com/kalva1/organisations/2c759a03-b961-43e2-9a47-db9a894dfe91/impacted/stops```