### PR TITLE
fix: "Edit" link within the user management page does not work

### DIFF
--- a/stacks/SiteStack.ts
+++ b/stacks/SiteStack.ts
@@ -146,6 +146,7 @@ export function SiteStack({ stack }: StackContext) {
                     "cognito-idp:AdminDeleteUser",
                     "cognito-idp:AdminCreateUser",
                     "cognito-idp:ListUsersInGroup",
+                    "cognito-idp:AdminListGroupsForUser",
                 ],
             }),
         ],

--- a/stacks/SiteStack.ts
+++ b/stacks/SiteStack.ts
@@ -147,6 +147,7 @@ export function SiteStack({ stack }: StackContext) {
                     "cognito-idp:AdminCreateUser",
                     "cognito-idp:ListUsersInGroup",
                     "cognito-idp:AdminListGroupsForUser",
+                    "cognito-idp:AdminRemoveUserFromGroup",
                 ],
             }),
         ],


### PR DESCRIPTION
After looking at logs:
{"level":"error","message":"Failed to retrieve group for user"}
'no identity-based policy allows the cognito-idp:AdminListGroupsForUser action' fixing this error

