### PR TITLE
feat: remove template features for operator users

### DIFF
--- a/site/components/ViewAllContents.tsx
+++ b/site/components/ViewAllContents.tsx
@@ -48,7 +48,6 @@ export interface ViewAllContentProps {
     filterStatus?: Progress | null;
     enableLoadingSpinnerOnPageLoad?: boolean;
     isTemplate?: boolean;
-    isOperatorUser?: boolean;
 }
 
 export interface Filter {

--- a/site/components/ViewAllContents.tsx
+++ b/site/components/ViewAllContents.tsx
@@ -48,6 +48,7 @@ export interface ViewAllContentProps {
     filterStatus?: Progress | null;
     enableLoadingSpinnerOnPageLoad?: boolean;
     isTemplate?: boolean;
+    isOperatorUser?: boolean;
 }
 
 export interface Filter {

--- a/site/pages/api/get-all-disruptions.api.ts
+++ b/site/pages/api/get-all-disruptions.api.ts
@@ -180,6 +180,11 @@ const getAllDisruptions = async (req: GetDisruptionsApiRequest, res: NextApiResp
         return;
     }
 
+    if (session.isOperatorUser && template) {
+        res.status(403);
+        return;
+    }
+
     const { orgId } = session;
 
     let disruptionsData = await getDisruptionsDataFromDynamo(orgId, template === "true");

--- a/site/pages/api/get-all-disruptions.api.ts
+++ b/site/pages/api/get-all-disruptions.api.ts
@@ -175,12 +175,7 @@ const getAllDisruptions = async (req: GetDisruptionsApiRequest, res: NextApiResp
 
     const { template } = req.query;
 
-    if (!session) {
-        res.status(403);
-        return;
-    }
-
-    if (session.isOperatorUser && template) {
+    if (!session || (session.isOperatorUser && template)) {
         res.status(403);
         return;
     }

--- a/site/pages/api/publish.api.ts
+++ b/site/pages/api/publish.api.ts
@@ -32,7 +32,7 @@ const publish = async (req: NextApiRequest, res: NextApiResponse) => {
         const session = getSession(req);
         const { template } = req.query;
 
-        if (!validatedBody.success || !session) {
+        if (!validatedBody.success || !session || (session.isOperatorUser && template)) {
             redirectTo(res, ERROR_PATH);
             return;
         }

--- a/site/pages/dashboard.page.tsx
+++ b/site/pages/dashboard.page.tsx
@@ -257,9 +257,11 @@ const Dashboard = ({
             <Link className="govuk-link" href="/view-all-disruptions?draft=true">
                 <h2 className="govuk-heading-s text-govBlue">Draft disruptions</h2>
             </Link>
-            <Link className="govuk-link" href="/view-all-templates">
-                <h2 className="govuk-heading-s text-govBlue">Templates</h2>
-            </Link>
+            {!isOperatorUser && (
+                <Link className="govuk-link" href="/view-all-templates">
+                    <h2 className="govuk-heading-s text-govBlue">Templates</h2>
+                </Link>
+            )}
         </BaseLayout>
     );
 };

--- a/site/pages/view-all-templates.page.tsx
+++ b/site/pages/view-all-templates.page.tsx
@@ -1,11 +1,9 @@
 import { Progress } from "@create-disruptions-data/shared-ts/enums";
-import { NextPageContext } from "next";
-import { redirect } from "next/navigation";
+import { NextPageContext, Redirect } from "next";
 import { ReactElement } from "react";
 import { randomUUID } from "crypto";
 import { BaseLayout } from "../components/layout/Layout";
 import ViewAllContents, { ViewAllContentProps } from "../components/ViewAllContents";
-import { ERROR_PATH } from "../constants";
 import { getSessionWithOrgDetail } from "../utils/apiUtils/auth";
 
 const title = "Templates";
@@ -30,7 +28,9 @@ const ViewAllTemplates = ({
     );
 };
 
-export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: ViewAllContentProps }> => {
+export const getServerSideProps = async (
+    ctx: NextPageContext,
+): Promise<{ props: ViewAllContentProps } | { redirect: Redirect }> => {
     const baseProps = {
         props: {
             newContentId: randomUUID(),
@@ -50,7 +50,12 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     }
 
     if (session.isOperatorUser) {
-        redirect(ERROR_PATH);
+        return {
+            redirect: {
+                destination: "/404",
+                statusCode: 302,
+            },
+        };
     }
 
     const showPending = ctx.query.pending?.toString() === "true";

--- a/site/pages/view-all-templates.page.tsx
+++ b/site/pages/view-all-templates.page.tsx
@@ -1,9 +1,11 @@
 import { Progress } from "@create-disruptions-data/shared-ts/enums";
 import { NextPageContext } from "next";
+import { redirect } from "next/navigation";
 import { ReactElement } from "react";
 import { randomUUID } from "crypto";
 import { BaseLayout } from "../components/layout/Layout";
 import ViewAllContents, { ViewAllContentProps } from "../components/ViewAllContents";
+import { ERROR_PATH } from "../constants";
 import { getSessionWithOrgDetail } from "../utils/apiUtils/auth";
 
 const title = "Templates";
@@ -45,6 +47,10 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
 
     if (!session) {
         return baseProps;
+    }
+
+    if (session.isOperatorUser) {
+        redirect(ERROR_PATH);
     }
 
     const showPending = ctx.query.pending?.toString() === "true";


### PR DESCRIPTION
- Removed template link from dashboard for operator users
- Added redirect on the "view-all-templates" page for operator users (goes to 404)
- Added guard in "get-all-disruptions" api to return an empty object if operator user tries to retrieve template info
- Added guard to "publish" api so that operators cannot publish a template