### PR TITLE
fix: batch emails for roadworks notifiers

### DIFF
--- a/packages/roadworks-notifier/cancelledNotifier.test.ts
+++ b/packages/roadworks-notifier/cancelledNotifier.test.ts
@@ -107,4 +107,78 @@ describe("roadWorksCancelledNotification", () => {
 
         expect(sesMock.send.calledOnce).toBeFalsy();
     });
+
+    it("should send an email when there is a cancelled roadwork and correctly split SES requests into batches of 50", async () => {
+        vi.spyOn(refDataApi, "getRecentlyCancelledRoadworks").mockResolvedValue([
+            {
+                permitReferenceNumber: "HZ73101328453-2339467-02",
+                highwayAuthoritySwaCode: 4230,
+                worksLocationCoordinates: "POINT(380416.24 399082.69)",
+                streetName: "FARRINGDON STREET",
+                areaName: "",
+                proposedStartDateTime: "2023-12-01T00:00:00.000Z",
+                proposedEndDateTime: "2023-12-01T00:00:00.000Z",
+                actualStartDateTime: "2023-12-01T09:30:00.000Z",
+                actualEndDateTime: null,
+                workStatus: "Works cancelled",
+                activityType: "Utility repair and maintenance works",
+                permitStatus: "cancelled",
+                town: "SALFORD",
+                administrativeAreaCode: "083",
+            },
+        ]);
+
+        vi.spyOn(dynamo, "getDisruptionsWithRoadworks").mockResolvedValue([
+            {
+                disruptionId: "d29b9753-d804-4912-9b90-07100ff35cfd",
+                disruptionType: "unplanned",
+                summary: "Farringdon Street - Utility repair and maintenance works",
+                description: "oh no ",
+                associatedLink: "",
+                disruptionReason: MiscellaneousReason.roadworks,
+                publishStartDate: "01/12/2023",
+                publishStartTime: "0930",
+                publishEndDate: "",
+                publishEndTime: "",
+                disruptionStartDate: "01/12/2023",
+                disruptionStartTime: "0930",
+                disruptionEndDate: "",
+                disruptionEndTime: "",
+                disruptionNoEndDateTime: "true",
+                disruptionRepeats: "doesntRepeat",
+                disruptionRepeatsEndDate: "",
+                validity: [],
+                displayId: "a10807",
+                orgId: "242ff2b2-19a0-421f-976f-22905262ebda",
+                creationTime: "2024-02-07T16:12:17.370Z",
+                permitReferenceNumber: "HZ73101328453-2339467-02",
+                consequences: [],
+                publishStatus: PublishStatus.published,
+                template: false,
+                lastUpdated: "2024-02-07T16:12:17.370Z",
+                history: [],
+            },
+        ]);
+
+        const listOfSixtyUsers: { email: string; orgId: string }[] = Array(60)
+            .fill("")
+            .map(() => ({
+                email: "test_email@.ac.uk",
+                orgId: "242ff2b2-19a0-421f-976f-22905262ebda",
+            }));
+
+        vi.spyOn(cognito, "getAllUsersEmailsInGroups").mockResolvedValue(listOfSixtyUsers);
+
+        const expectedToAddresses = listOfSixtyUsers.map((user) => user.email);
+
+        await main();
+
+        expect(sesMock.send.calledTwice).toBeTruthy();
+        expect(sesMock.commandCalls(SendEmailCommand)[0].args[0].input.Destination).toEqual({
+            ToAddresses: expectedToAddresses.slice(0, 50),
+        });
+        expect(sesMock.commandCalls(SendEmailCommand)[1].args[0].input.Destination).toEqual({
+            ToAddresses: expectedToAddresses.slice(50, 60),
+        });
+    });
 });

--- a/packages/roadworks-notifier/newNotifier.test.ts
+++ b/packages/roadworks-notifier/newNotifier.test.ts
@@ -69,4 +69,50 @@ describe("roadWorksCancelledNotification", () => {
 
         expect(sesMock.send.calledOnce).toBeFalsy();
     });
+
+    it("should send an email when there is a new roadwork and split calls into batches of 50", async () => {
+        vi.spyOn(refDataApi, "getRecentlyNewRoadworks").mockResolvedValue([
+            {
+                permitReferenceNumber: "HZ73101328453-2339467-02",
+                highwayAuthoritySwaCode: 4230,
+                worksLocationCoordinates: "POINT(380416.24 399082.69)",
+                streetName: "FARRINGDON STREET",
+                areaName: "",
+                proposedStartDateTime: "2023-12-01T00:00:00.000Z",
+                proposedEndDateTime: "2023-12-01T00:00:00.000Z",
+                actualStartDateTime: "2023-12-01T09:30:00.000Z",
+                actualEndDateTime: null,
+                workStatus: "Works in progress",
+                activityType: "Utility repair and maintenance works",
+                permitStatus: "granted",
+                town: "SALFORD",
+                administrativeAreaCode: "083",
+            },
+        ]);
+
+        vi.spyOn(dynamo, "getOrgIdsFromDynamoByAdminAreaCodes").mockResolvedValue({
+            "242ff2b2-19a0-421f-976f-22905262ebda": ["083"],
+        });
+
+        const listOfSixtyEmails: string[] = Array(60)
+            .fill("")
+            .map(() => "test_email@.ac.uk");
+
+        vi.spyOn(cognito, "getUsersByAttributeByOrgIds").mockResolvedValue({
+            "242ff2b2-19a0-421f-976f-22905262ebda": {
+                emails: listOfSixtyEmails,
+                adminAreaCodes: ["083"],
+            },
+        });
+
+        await main();
+
+        expect(sesMock.send.calledTwice).toBeTruthy();
+        expect(sesMock.commandCalls(SendEmailCommand)[0].args[0].input.Destination).toEqual({
+            ToAddresses: listOfSixtyEmails.slice(0, 50),
+        });
+        expect(sesMock.commandCalls(SendEmailCommand)[1].args[0].input.Destination).toEqual({
+            ToAddresses: listOfSixtyEmails.slice(50, 60),
+        });
+    });
 });

--- a/shared-ts/utils/index.ts
+++ b/shared-ts/utils/index.ts
@@ -9,6 +9,16 @@ export const notEmpty = <T>(value: T | null | undefined): value is T => {
     return value !== null && value !== undefined;
 };
 
+export const chunkArray = <T>(array: T[], chunkSize: number) => {
+    const chunkArray = [];
+
+    for (let i = 0; i < array.length; i += chunkSize) {
+        chunkArray.push(array.slice(i, i + chunkSize));
+    }
+
+    return chunkArray;
+};
+
 export const getApiValidityPeriods = (validityPeriods: Validity[]) =>
     validityPeriods.map(({ disruptionNoEndDateTime, ...validity }) => ({
         ...validity,


### PR DESCRIPTION
Bug found when testing the cancelled roadwork notification. SES cannot send emails to more than 50 users at once. This PR is to batch emails into groups of 50 for both cancelled and new roadworks notifications - updated tests accordingly.