### PR TITLE
fix: Incorrect error message displayed when creating a new operator

### DIFF
--- a/site/components/page-templates/UserDetailPageTemplate.tsx
+++ b/site/components/page-templates/UserDetailPageTemplate.tsx
@@ -152,7 +152,9 @@ const UserDetailPageTemplate = ({
                                 <input
                                     type="hidden"
                                     name="operatorOrg"
-                                    value={JSON.stringify(pageState.inputs.operatorOrg)}
+                                    value={
+                                        pageState.inputs.operatorOrg ? JSON.stringify(pageState.inputs.operatorOrg) : ""
+                                    }
                                 />
                             </>
                         )}


### PR DESCRIPTION
The empty string was being stringified with multiple clicks of the submit button. This simple check means if there is no operator in the state do not stringify it.

To test:
Go to add user and then select operator, click submit, wait and click submit again - the error message should be correct.