### PR TITLE
feat: BODS-819 allow additional naptan stop types 

### DIFF
--- a/site/components/map/ServicesMap.tsx
+++ b/site/components/map/ServicesMap.tsx
@@ -277,12 +277,10 @@ const ServicesMap = ({
                 setLoading(true);
                 const vehicleMode = state.inputs.vehicleMode as Modes | VehicleMode;
                 try {
-                    const stopTypes = getStopTypesByVehicleMode(vehicleMode);
                     const stopsData = await fetchStops({
                         adminAreaCodes: state.sessionWithOrg?.adminAreaCodes ?? ["undefined"],
                         polygon,
-                        busStopTypes: stopTypes.busStopTypes,
-                        stopTypes: stopTypes.stopTypes.split(", "),
+                        stopTypes: getStopTypesByVehicleMode(vehicleMode),
                     });
 
                     const filteredStopList = filterStopList(stopsData, vehicleMode, showUnderground);

--- a/site/components/map/StopsMap.tsx
+++ b/site/components/map/StopsMap.tsx
@@ -17,7 +17,7 @@ import { z } from "zod";
 import { fetchStops } from "../../data/refDataApi";
 import { LargePolygonError, NoStopsError } from "../../errors";
 import { PageState } from "../../interfaces";
-import { filterStopList, flattenZodErrors } from "../../utils";
+import { filterStopList, flattenZodErrors, getStopTypesByVehicleMode } from "../../utils";
 import { getStopType, sortAndFilterStops } from "../../utils/formUtils";
 import { warningMessageText } from "../../utils/mapUtils";
 import Warning from "../form/Warning";
@@ -137,22 +137,12 @@ const Map = ({
             const loadOptions = async () => {
                 setLoading(true);
                 const vehicleMode = state.inputs.vehicleMode as Modes | VehicleMode;
+
                 try {
                     const stopsData = await fetchStops({
                         adminAreaCodes: state.sessionWithOrg?.adminAreaCodes ?? ["undefined"],
                         polygon,
-                        ...(vehicleMode === VehicleMode.bus ? { busStopTypes: "MKD,CUS" } : {}),
-                        ...(vehicleMode === VehicleMode.bus
-                            ? { stopTypes: ["BCT"] }
-                            : vehicleMode === VehicleMode.tram ||
-                                vehicleMode === Modes.metro ||
-                                vehicleMode === VehicleMode.underground
-                              ? { stopTypes: ["MET", "PLT"] }
-                              : vehicleMode === Modes.ferry || vehicleMode === VehicleMode.ferryService
-                                ? { stopTypes: ["FER", "FBT"] }
-                                : vehicleMode === Modes.rail
-                                  ? { stopTypes: ["RLY"] }
-                                  : { stopTypes: ["undefined"] }),
+                        stopTypes: getStopTypesByVehicleMode(vehicleMode),
                     });
 
                     const filteredStopList = filterStopList(stopsData, vehicleMode, showUnderground);

--- a/site/data/refDataApi.ts
+++ b/site/data/refDataApi.ts
@@ -15,7 +15,6 @@ interface FetchStopsInput {
     polygon?: Position[];
     searchString?: string;
     stopTypes?: string[];
-    busStopTypes?: string;
 }
 
 export const fetchStops = async (input: FetchStopsInput) => {
@@ -33,9 +32,6 @@ export const fetchStops = async (input: FetchStopsInput) => {
 
     if (input.stopTypes) {
         queryStringItems.push(`stopTypes=${input.stopTypes.join(",")}`);
-    }
-    if (input.busStopTypes) {
-        queryStringItems.push(`busStopTypes=${input.busStopTypes}`);
     }
 
     const res = await fetch(`${searchApiUrl}${queryStringItems.length > 0 ? `?${queryStringItems.join("&")}` : ""}`, {
@@ -181,9 +177,7 @@ export const fetchJourneys = async (input: FetchJourneysInput) => {
 interface FetchServiceRoutes {
     serviceRef: string;
     dataSource: Datasource;
-    busStopTypes?: string;
     modes?: string;
-    stopTypes?: string;
 }
 
 export const fetchServiceRoutes = async (input: FetchServiceRoutes) => {
@@ -193,14 +187,6 @@ export const fetchServiceRoutes = async (input: FetchServiceRoutes) => {
 
     if (input.modes) {
         queryStringItems.push(`modes=${input.modes}`);
-    }
-
-    if (input.busStopTypes) {
-        queryStringItems.push(`busStopTypes=${input.busStopTypes}`);
-    }
-
-    if (input.stopTypes) {
-        queryStringItems.push(`stopTypes=${input.stopTypes}`);
     }
 
     const res = await fetch(`${searchApiUrl}${queryStringItems.length > 0 ? `?${queryStringItems.join("&")}` : ""}`, {
@@ -219,9 +205,7 @@ export const fetchServiceRoutes = async (input: FetchServiceRoutes) => {
 interface FetchServiceStops {
     serviceRef: string;
     dataSource: Datasource;
-    busStopTypes?: string;
     modes?: string;
-    stopTypes?: string;
 }
 
 export const fetchServiceStops = async (input: FetchServiceStops) => {
@@ -230,14 +214,6 @@ export const fetchServiceStops = async (input: FetchServiceStops) => {
 
     if (input.modes) {
         queryStringItems.push(`modes=${input.modes}`);
-    }
-
-    if (input.busStopTypes) {
-        queryStringItems.push(`busStopTypes=${input.busStopTypes}`);
-    }
-
-    if (input.stopTypes) {
-        queryStringItems.push(`stopTypes=${input.stopTypes}`);
     }
 
     const res = await fetch(`${searchApiUrl}${queryStringItems.length > 0 ? `?${queryStringItems.join("&")}` : ""}`, {

--- a/site/pages/create-consequence-journeys/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-journeys/[disruptionId]/[consequenceIndex].page.tsx
@@ -46,7 +46,6 @@ import {
     filterVehicleModes,
     flattenZodErrors,
     getServiceLabel,
-    getStopTypesByVehicleMode,
     getStops,
     isJourneysConsequence,
 } from "../../../utils";
@@ -151,12 +150,10 @@ const CreateConsequenceJourneys = (props: CreateConsequenceJourneysProps): React
 
                 await Promise.all(
                     pageState.inputs.services.map(async (s) => {
-                        const stopTypes = getStopTypesByVehicleMode(vehicleMode);
                         const serviceRoutesData = await fetchServiceRoutes({
                             serviceRef: s.dataSource === Datasource.bods ? s.lineId : s.serviceCode,
                             dataSource: s.dataSource,
                             modes: vehicleMode === VehicleMode.tram ? "tram, metro" : vehicleMode,
-                            ...stopTypes,
                         });
 
                         if (serviceRoutesData) {

--- a/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-services/[disruptionId]/[consequenceIndex].page.tsx
@@ -47,7 +47,6 @@ import {
     flattenZodErrors,
     getRoutesForServices,
     getServiceLabel,
-    getStopTypesByVehicleMode,
     getStops,
     getStopsForRoutes,
     isServicesConsequence,
@@ -155,12 +154,10 @@ const CreateConsequenceServices = (props: CreateConsequenceServicesProps): React
                 const vehicleMode = pageState?.inputs?.vehicleMode || ("" as Modes | VehicleMode);
                 await Promise.all(
                     pageState.inputs.services.map(async (s) => {
-                        const stopTypes = getStopTypesByVehicleMode(vehicleMode);
                         const serviceRoutesData = await fetchServiceRoutes({
                             serviceRef: s.dataSource === Datasource.bods ? s.lineId : s.serviceCode,
                             dataSource: s.dataSource,
                             modes: vehicleMode === VehicleMode.tram ? "tram, metro" : vehicleMode,
-                            ...stopTypes,
                         });
 
                         if (serviceRoutesData) {

--- a/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
+++ b/site/pages/create-consequence-stops/[disruptionId]/[consequenceIndex].page.tsx
@@ -36,7 +36,13 @@ import {
 import { getDisruptionById } from "../../../data/dynamo";
 import { fetchStops } from "../../../data/refDataApi";
 import { CreateConsequenceProps, PageState } from "../../../interfaces";
-import { filterStopList, filterVehicleModes, flattenZodErrors, isStopsConsequence } from "../../../utils";
+import {
+    filterStopList,
+    filterVehicleModes,
+    flattenZodErrors,
+    getStopTypesByVehicleMode,
+    isStopsConsequence,
+} from "../../../utils";
 import { destroyCookieOnResponseObject, getPageState } from "../../../utils/apiUtils";
 import { getSessionWithOrgDetail } from "../../../utils/apiUtils/auth";
 import {
@@ -85,22 +91,12 @@ const CreateConsequenceStops = (props: CreateConsequenceStopsProps): ReactElemen
         const loadOptions = async () => {
             if (searchInput.length >= 3) {
                 const vehicleMode = pageState.inputs.vehicleMode as Modes | VehicleMode;
+
                 try {
                     const stopsData = await fetchStops({
                         adminAreaCodes: props.sessionWithOrg?.adminAreaCodes ?? ["undefined"],
                         searchString: searchInput,
-                        ...(vehicleMode === VehicleMode.bus ? { busStopTypes: "MKD,CUS" } : {}),
-                        ...(vehicleMode === VehicleMode.bus
-                            ? { stopTypes: ["BCT"] }
-                            : vehicleMode === VehicleMode.tram ||
-                                vehicleMode === Modes.metro ||
-                                vehicleMode === VehicleMode.underground
-                              ? { stopTypes: ["MET", "PLT"] }
-                              : vehicleMode === Modes.ferry || vehicleMode === VehicleMode.ferryService
-                                ? { stopTypes: ["FER", "FBT"] }
-                                : vehicleMode === Modes.rail
-                                  ? { stopTypes: ["RLY"] }
-                                  : { stopTypes: ["undefined"] }),
+                        stopTypes: getStopTypesByVehicleMode(vehicleMode),
                     });
 
                     const filteredStopList = filterStopList(stopsData, vehicleMode, props.showUnderground);

--- a/site/utils/formUtils.test.ts
+++ b/site/utils/formUtils.test.ts
@@ -7,7 +7,7 @@ import {
     mockTndsServicesNoDuplicates,
     mockTndsServicesWithDuplicates,
 } from "../testData/mockData";
-import { filterServices, removeDuplicateServicesByKey, sortAndFilterStops } from "./formUtils";
+import { filterServices, getStopType, removeDuplicateServicesByKey, sortAndFilterStops } from "./formUtils";
 
 describe("formUtils", () => {
     afterEach(() => {
@@ -132,6 +132,21 @@ describe("formUtils", () => {
         });
         it("should an empty array when there are no stops passed in", () => {
             expect(sortAndFilterStops([])).toEqual([]);
+        });
+    });
+
+    describe("getStopType", () => {
+        it.each([
+            ["BCT", "Bus stop"],
+            ["BCS", "Bus stop"],
+            ["BCQ", "Bus stop"],
+            ["MET", "Tram stop"],
+            ["PLT", "Tram stop"],
+            ["FER", "Ferry terminal"],
+            ["FBT", "Ferry terminal"],
+            [undefined, "Stop"],
+        ])("should return the correct name for a given stop type", (stopType, stopName) => {
+            expect(getStopType(stopType)).toEqual(stopName);
         });
     });
 });

--- a/site/utils/formUtils.ts
+++ b/site/utils/formUtils.ts
@@ -91,7 +91,7 @@ export const getDataInPages = <T>(pageNumber: number, data: T[]): T[] => {
 };
 
 export const getStopType = (stopType: string | undefined) => {
-    if (stopType === "BCT") {
+    if (stopType === "BCT" || stopType === "BCS" || stopType === "BCQ") {
         return "Bus stop";
     }
     if (stopType === "MET" || stopType === "PLT") {

--- a/site/utils/index.test.ts
+++ b/site/utils/index.test.ts
@@ -4,11 +4,18 @@ import {
     disruptionInfoSchema,
     operatorConsequenceSchema,
 } from "@create-disruptions-data/shared-ts/disruptionTypes.zod";
-import { MiscellaneousReason, PublishStatus, Severity, VehicleMode } from "@create-disruptions-data/shared-ts/enums";
+import {
+    MiscellaneousReason,
+    Modes,
+    PublishStatus,
+    Severity,
+    VehicleMode,
+} from "@create-disruptions-data/shared-ts/enums";
 import { describe, expect, it } from "vitest";
 import {
     filterDisruptionsForOperatorUser,
     generatePassword,
+    getStopTypesByVehicleMode,
     removeDuplicatesBasedOnMode,
     splitCamelCaseToString,
     toTitleCase,
@@ -440,5 +447,18 @@ describe("generatePassword", () => {
         const isPasswordValid = validatePassword(password);
 
         expect(isPasswordValid).toEqual(true);
+    });
+});
+describe("getStopTypesByVehicleMode", () => {
+    it.each([
+        [VehicleMode.bus, ["BCT", "BCS", "BCQ"]],
+        [VehicleMode.coach, ["BCT", "BCS", "BCQ"]],
+        [VehicleMode.tram, ["MET", "PLT"]],
+        [Modes.metro, ["MET", "PLT"]],
+        [VehicleMode.underground, ["MET", "PLT"]],
+        [Modes.ferry, ["FER", "FBT"]],
+        [VehicleMode.ferryService, ["FER", "FBT"]],
+    ])("should return the correct stop types for a given mode", (mode, stopType) => {
+        expect(getStopTypesByVehicleMode(mode)).toEqual(stopType);
     });
 });

--- a/site/utils/index.ts
+++ b/site/utils/index.ts
@@ -158,12 +158,10 @@ export const getStops = async (
     if (serviceRef) {
         let stopsData: Stop[] = [];
         if (vehicleMode) {
-            const stopTypes = getStopTypesByVehicleMode(vehicleMode);
             stopsData = await fetchServiceStops({
                 serviceRef,
                 dataSource,
                 modes: vehicleMode === VehicleMode.tram ? "tram, metro" : vehicleMode,
-                ...stopTypes,
             });
         }
         if (stopsData) {
@@ -265,21 +263,17 @@ export const filterStopList = (stops: Stop[], vehicleMode: VehicleMode | Modes, 
 export const getStopTypesByVehicleMode = (vehicleMode: VehicleMode | Modes) => {
     switch (vehicleMode) {
         case VehicleMode.bus:
-            return {
-                busStopTypes: "MKD,CUS",
-                stopTypes: "BCT",
-            };
+        case Modes.coach:
+            return ["BCT", "BCS", "BCQ"];
         case VehicleMode.tram:
         case Modes.metro:
         case VehicleMode.underground:
-            return { stopTypes: "MET, PLT" };
+            return ["MET", "PLT"];
         case Modes.ferry:
         case VehicleMode.ferryService:
-            return { stopTypes: "FER, FBT" };
-        case Modes.coach:
-            return { stopTypes: "BCT, BCS" };
+            return ["FER", "FBT"];
         default:
-            return { stopTypes: "undefined" };
+            return [];
     }
 };
 


### PR DESCRIPTION
- update calls to ref data service to include additional stop types BCS and BCQ (inc coaches)
- remove busStopTypes as queryParam to ref data service