### PR TITLE
chore: update govuk-frontend to 5.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,8 +826,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       govuk-frontend:
-        specifier: 5.10.2
-        version: 5.10.2
+        specifier: 5.11.0
+        version: 5.11.0
       jose:
         specifier: ^4.15.5
         version: 4.15.9
@@ -5902,8 +5902,8 @@ packages:
   govuk-colours@1.1.0:
     resolution: {integrity: sha512-EcwnP9PsWubmTcsJtLF8w0D5b69j43LwYtSqGyPtO3903J0bbwB2t5ujWZ9UhsbLamuUmigBkNpLItU3/KuFqw==}
 
-  govuk-frontend@5.10.2:
-    resolution: {integrity: sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==}
+  govuk-frontend@5.11.0:
+    resolution: {integrity: sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==}
     engines: {node: '>= 4.2.0'}
 
   graceful-fs@4.2.11:
@@ -16261,7 +16261,7 @@ snapshots:
 
   govuk-colours@1.1.0: {}
 
-  govuk-frontend@5.10.2: {}
+  govuk-frontend@5.11.0: {}
 
   graceful-fs@4.2.11: {}
 

--- a/site/components/layout/CookieBanner.tsx
+++ b/site/components/layout/CookieBanner.tsx
@@ -9,7 +9,7 @@ interface CookieBannerMessageProps {
 }
 
 export const CookieBannerMessage = ({ handleClick }: CookieBannerMessageProps): ReactElement => (
-    <div id="global-cookie-message" className="pt-4" role="region" aria-label="cookie banner">
+    <div id="global-cookie-message" className="govuk-cookie-banner" role="region" aria-label="cookie banner">
         <div className="govuk-width-container relative">
             <div className="govuk-grid-row">
                 <div className="govuk-grid-column-two-thirds">

--- a/site/components/layout/CookieBanner.tsx
+++ b/site/components/layout/CookieBanner.tsx
@@ -92,23 +92,26 @@ const CookieBanner = (): ReactElement | null => {
 
     if (cookiesAccepted) {
         return (
-            <div id="cookies-accepted-message" className="py-5 text-lg" role="region" aria-label="cookie banner">
-                <div className="govuk-width-container relative">
-                    <p role="alert">
-                        You’ve accepted all cookies. You can{" "}
-                        <Link className="govuk-link" href="/cookies">
-                            change your cookie settings
-                        </Link>{" "}
-                        at any time.
-                    </p>
-                    <button
-                        className="govuk-link text-govBlue hover:text-hoverBlue cursor-pointer text-lg absolute right-0 p-0 top-[-1px] max-md:static"
-                        type="button"
-                        id="hide"
-                        onClick={handleHideClick}
-                    >
-                        Hide
-                    </button>
+            <div id="cookies-accepted-message" className="govuk-cookie-banner" role="region" aria-label="cookie banner">
+                <div className="govuk-cookie-banner__message govuk-width-container">
+                    <div className="govuk-grid-row">
+                        <div className="govuk-grid-column-two-thirds">
+                            <div className="govuk-cookie-banner__content">
+                                <p className="govuk-body">
+                                    You’ve accepted all cookies. You can{" "}
+                                    <a className="govuk-link" href="/cookies">
+                                        change your cookie settings
+                                    </a>{" "}
+                                    at any time.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="govuk-button-group">
+                        <button className="govuk-button" type="button" onClick={handleHideClick}>
+                            Hide
+                        </button>
+                    </div>
                 </div>
             </div>
         );

--- a/site/components/layout/__snapshots__/CookieBanner.test.tsx.snap
+++ b/site/components/layout/__snapshots__/CookieBanner.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CookieBanner > should render correctly 1`] = `
 <div>
   <div
     aria-label="cookie banner"
-    class="pt-4"
+    class="govuk-cookie-banner"
     id="global-cookie-message"
     role="region"
   >
@@ -73,34 +73,49 @@ exports[`CookieBanner > should render correctly when accept all is clicked 1`] =
 <div>
   <div
     aria-label="cookie banner"
-    class="py-5 text-lg"
+    class="govuk-cookie-banner"
     id="cookies-accepted-message"
     role="region"
   >
     <div
-      class="govuk-width-container relative"
+      class="govuk-cookie-banner__message govuk-width-container"
     >
-      <p
-        role="alert"
+      <div
+        class="govuk-grid-row"
       >
-        You’ve accepted all cookies. You can
-         
-        <a
-          class="govuk-link"
-          href="/cookies"
+        <div
+          class="govuk-grid-column-two-thirds"
         >
-          change your cookie settings
-        </a>
-         
-        at any time.
-      </p>
-      <button
-        class="govuk-link text-govBlue hover:text-hoverBlue cursor-pointer text-lg absolute right-0 p-0 top-[-1px] max-md:static"
-        id="hide"
-        type="button"
+          <div
+            class="govuk-cookie-banner__content"
+          >
+            <p
+              class="govuk-body"
+            >
+              You’ve accepted all cookies. You can
+               
+              <a
+                class="govuk-link"
+                href="/cookies"
+              >
+                change your cookie settings
+              </a>
+               
+              at any time.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="govuk-button-group"
       >
-        Hide
-      </button>
+        <button
+          class="govuk-button"
+          type="button"
+        >
+          Hide
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/site/package.json
+++ b/site/package.json
@@ -42,7 +42,7 @@
         "focus-trap-react": "^10.2.3",
         "formidable": "^3.5.4",
         "geojson": "^0.5.0",
-        "govuk-frontend": "5.10.2",
+        "govuk-frontend": "5.11.0",
         "jose": "^4.15.5",
         "jsonwebtoken": "^9.0.0",
         "kysely": "^0.27.5",


### PR DESCRIPTION
includes fix for cookier banner