### PR TITLE
fix: Handle missing long lat in txc uploader

### DIFF
--- a/.sst/types/index.ts
+++ b/.sst/types/index.ts
@@ -63,7 +63,16 @@ declare module "sst/node/config" {
 import "sst/node/function";
 declare module "sst/node/function" {
   export interface FunctionResources {
-    "cdd-local-database-creator-function": {
+    "cdd-kysely-db-migrator-migrate-function": {
+      functionName: string;
+    }
+  }
+}
+
+import "sst/node/function";
+declare module "sst/node/function" {
+  export interface FunctionResources {
+    "cdd-kysely-db-migrator-rollback-function": {
       functionName: string;
     }
   }

--- a/.sst/types/index.ts
+++ b/.sst/types/index.ts
@@ -63,16 +63,7 @@ declare module "sst/node/config" {
 import "sst/node/function";
 declare module "sst/node/function" {
   export interface FunctionResources {
-    "cdd-kysely-db-migrator-migrate-function": {
-      functionName: string;
-    }
-  }
-}
-
-import "sst/node/function";
-declare module "sst/node/function" {
-  export interface FunctionResources {
-    "cdd-kysely-db-migrator-rollback-function": {
+    "cdd-local-database-creator-function": {
       functionName: string;
     }
   }

--- a/packages/txc-uploader/txc_processor.py
+++ b/packages/txc-uploader/txc_processor.py
@@ -885,7 +885,7 @@ def check_file_has_usable_data(data: dict, service: dict) -> bool:
 
 
 def insert_into_txc_tracks_table(cursor: Cursor, tracks, operator_service_id):
-    batched_tracks = [tracks[i: i + 200] for i in range(0, len(tracks), 200)]
+    batched_tracks = [tracks[i : i + 200] for i in range(0, len(tracks), 200)]
 
     for batch in batched_tracks:
 
@@ -953,8 +953,8 @@ def collect_track_data(route_sections, route_section_refs, link_refs):
                                                 location
                                             )
                                             if (
-                                                    longitude is not None
-                                                    and latitude is not None
+                                                longitude is not None
+                                                and latitude is not None
                                             ):
                                                 routes.append(
                                                     {

--- a/stacks/RefDataStepFunctionStack.ts
+++ b/stacks/RefDataStepFunctionStack.ts
@@ -188,7 +188,7 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
             bind: [tndsFtpHostSecret, tndsFtpUsernameSecret, tndsFtpPasswordSecret],
             handler: "packages/tnds-txc-retriever/index.main",
             timeout: 120,
-            memorySize: 1024,
+            memorySize: 2048,
             diskSize: 1024,
             runtime: "nodejs22.x",
             logRetention: stack.stage === "prod" ? "one_month" : "two_weeks",
@@ -469,6 +469,7 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
             prefix: JsonPath.stringAt("$.prefix"),
         }),
         resultPath: JsonPath.DISCARD,
+        toleratedFailureCount: 10,
     });
 
     zippedObjectsMap.itemProcessor(unzipperTask);


### PR DESCRIPTION
We are in the process of migrating the reference data service to this repo.

This PR copies over the following changes that were completed in the reference data service:
- handle missing long/lat data
- memory bump to the tnds retriever lambda to handle increase in TNDS data
- allow for a small number of failures for processing of TXC data (this was added due to BODS providing a small number (~5) empty zips, in this case we still want to continue to step function and process the rest of the TXC data)