### PR TITLE
chore: Disable ref data migration changes for prod site and functions

### DIFF
--- a/stacks/RoadworksNotificationStack.ts
+++ b/stacks/RoadworksNotificationStack.ts
@@ -8,6 +8,7 @@ import { DynamoDBStack } from "./DynamoDBStack";
 import { MonitoringStack } from "./MonitoringStack";
 import { RdsStack } from "./RdsStack";
 import { VpcStack } from "./VpcStack";
+import { getRefDataApiUrl } from "./utils";
 
 export const RoadworksNotificationStack = ({ stack }: StackContext) => {
     const { organisationsTableV2: organisationsTable } = use(DynamoDBStack);
@@ -17,9 +18,7 @@ export const RoadworksNotificationStack = ({ stack }: StackContext) => {
         use(RdsStack);
     const { vpc, lambdaSg } = use(VpcStack);
 
-    const apiUrl = !["test", "preprod", "prod"].includes(stack.stage)
-        ? `https://ref-data-api.${stack.stage}.sandbox.cdd.dft-create-data.com/v1`
-        : `https://ref-data-api.${stack.stage}.cdd.dft-create-data.com/v1`;
+    const apiUrl = getRefDataApiUrl(stack.stage);
 
     const url =
         stack.stage === "prod"

--- a/stacks/SiriAPIStack.ts
+++ b/stacks/SiriAPIStack.ts
@@ -8,7 +8,7 @@ import { DynamoDBStack } from "./DynamoDBStack";
 import { RdsStack } from "./RdsStack";
 import { SiriGeneratorStack } from "./SiriGeneratorStack";
 import { VpcStack } from "./VpcStack";
-import { isUserEnv } from "./utils";
+import { getRefDataApiUrl, isUserEnv } from "./utils";
 
 export const SiriAPIStack = ({ stack }: StackContext) => {
     const { siriSXBucket, disruptionsJsonBucket, disruptionsCsvBucket } = use(SiriGeneratorStack);
@@ -21,9 +21,7 @@ export const SiriAPIStack = ({ stack }: StackContext) => {
         return;
     }
 
-    const apiUrl = !["test", "preprod", "prod"].includes(stack.stage)
-        ? `https://ref-data-api.${stack.stage}.sandbox.cdd.dft-create-data.com/v1`
-        : `https://ref-data-api.${stack.stage}.cdd.dft-create-data.com/v1`;
+    const apiUrl = getRefDataApiUrl(stack.stage);
 
     const subDomain = ["sandbox", "test", "preprod", "prod"].includes(stack.stage) ? "api" : `api.${stack.stage}`;
 

--- a/stacks/SiriGeneratorStack.ts
+++ b/stacks/SiriGeneratorStack.ts
@@ -10,7 +10,7 @@ import { DynamoDBStack } from "./DynamoDBStack";
 import { MonitoringStack } from "./MonitoringStack";
 import { RdsStack } from "./RdsStack";
 import { VpcStack } from "./VpcStack";
-import { createBucket } from "./utils";
+import { createBucket, getRefDataApiUrl } from "./utils";
 
 export const SiriGeneratorStack = ({ stack }: StackContext) => {
     const { organisationsTableV2: organisationsTable } = use(DynamoDBStack);
@@ -46,9 +46,7 @@ export const SiriGeneratorStack = ({ stack }: StackContext) => {
         },
     ]);
 
-    const apiUrl = !["preprod", "prod"].includes(stack.stage)
-        ? "https://api.test.ref-data.dft-create-data.com/v1"
-        : `https://api.${stack.stage}.ref-data.dft-create-data.com/v1`;
+    const apiUrl = getRefDataApiUrl(stack.stage);
 
     const siriGenerator = new Function(stack, "cdd-siri-sx-generator", {
         functionName: `cdd-siri-sx-generator-${stack.stage}`,

--- a/stacks/SiteStack.ts
+++ b/stacks/SiteStack.ts
@@ -11,7 +11,7 @@ import { DynamoDBStack } from "./DynamoDBStack";
 import { MonitoringStack } from "./MonitoringStack";
 import { RdsStack } from "./RdsStack";
 import { VpcStack } from "./VpcStack";
-import { createBucket, isUserEnv } from "./utils";
+import { createBucket, getRefDataApiUrl, isUserEnv } from "./utils";
 
 export const SiteStack = ({ stack }: StackContext) => {
     const { organisationsTableV2: organisationsTable } = use(DynamoDBStack);
@@ -35,9 +35,7 @@ export const SiteStack = ({ stack }: StackContext) => {
         }
     }
 
-    const apiUrl = !["test", "preprod", "prod"].includes(stack.stage)
-        ? `https://ref-data-api.${stack.stage}.sandbox.cdd.dft-create-data.com/v1`
-        : `https://ref-data-api.${stack.stage}.cdd.dft-create-data.com/v1`;
+    const apiUrl = getRefDataApiUrl(stack.stage);
 
     const middlewareCognitoUser = new User(stack, "cdd-site-middleware-user", {
         userName: `cdd-site-middleware-user-${stack.stage}-${stack.region}`,

--- a/stacks/utils/index.ts
+++ b/stacks/utils/index.ts
@@ -30,3 +30,15 @@ export const createBucket = (
 export const isUserEnv = (stage: string) => !["sandbox", "test", "preprod", "prod"].includes(stage);
 
 export const isSharedSandboxEnv = (stage: string) => stage === "sandbox";
+
+export const getRefDataApiUrl = (stage: string) => {
+    const oldRefDataApiUrl = !["preprod", "prod"].includes(stage)
+        ? "https://api.test.ref-data.dft-create-data.com/v1"
+        : `https://api.${stage}.ref-data.dft-create-data.com/v1`;
+
+    const disruptionsRefDataApiUrl = !["test", "preprod", "prod"].includes(stage)
+        ? `https://ref-data-api.${stage}.sandbox.cdd.dft-create-data.com/v1`
+        : `https://ref-data-api.${stage}.cdd.dft-create-data.com/v1`;
+
+    return ["prod"].includes(stage) ? oldRefDataApiUrl : disruptionsRefDataApiUrl;
+};


### PR DESCRIPTION
Disable the prod site and functions (e.g. SIRI-SX generator and Roadworks Notifier) from using the new disruptions ref data API url. 

This is to unblock releases of other features whilst testing of the new disruptions ref data migration occurs on lower environments.