### PR TITLE
DBODS-1629: Read NOC Data from S3

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -81,5 +81,9 @@ jobs:
           NPTG_BUCKET_NAME: ${{ vars.NAPTAN_BUCKET_NAME }}
           NPTG_ROLE_ARN: ${{ vars.NAPTAN_ROLE_ARN }}
           NPTG_BUCKET_KEY: ${{ vars.NPTG_BUCKET_KEY }}
+          NOC_BUCKET_NAME: ${{ vars.NOC_BUCKET_NAME }}
+          NOC_BUCKET_REGION: ${{ vars.NOC_BUCKET_REGION }}
+          NOC_BUCKET_KEY: ${{ vars.NOC_BUCKET_KEY }}
+          NOC_ROLE_ARN: ${{ vars.NOC_ROLE_ARN }}
         run: |
           pnpm run deploy --stage ${{ inputs.stage }}

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -116,6 +116,10 @@ jobs:
           NPTG_BUCKET_NAME: ${{ vars.NAPTAN_BUCKET_NAME }}
           NPTG_ROLE_ARN: ${{ vars.NAPTAN_ROLE_ARN }}
           NPTG_BUCKET_KEY: ${{ vars.NPTG_BUCKET_KEY }}
+          NOC_BUCKET_NAME: ${{ vars.NOC_BUCKET_NAME }}
+          NOC_BUCKET_REGION: ${{ vars.NOC_BUCKET_REGION }}
+          NOC_BUCKET_KEY: ${{ vars.NOC_BUCKET_KEY }}
+          NOC_ROLE_ARN: ${{ vars.NOC_ROLE_ARN }}
         run: |
           pnpm run deploy --stage test
 
@@ -182,6 +186,10 @@ jobs:
           NPTG_BUCKET_NAME: ${{ vars.NAPTAN_BUCKET_NAME }}
           NPTG_ROLE_ARN: ${{ vars.NAPTAN_ROLE_ARN }}
           NPTG_BUCKET_KEY: ${{ vars.NPTG_BUCKET_KEY }}
+          NOC_BUCKET_NAME: ${{ vars.NOC_BUCKET_NAME }}
+          NOC_BUCKET_REGION: ${{ vars.NOC_BUCKET_REGION }}
+          NOC_BUCKET_KEY: ${{ vars.NOC_BUCKET_KEY }}
+          NOC_ROLE_ARN: ${{ vars.NOC_ROLE_ARN }}
         run: |
           pnpm run deploy --stage preprod
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -68,6 +68,10 @@ jobs:
           NPTG_BUCKET_NAME: ${{ vars.NAPTAN_BUCKET_NAME }}
           NPTG_ROLE_ARN: ${{ vars.NAPTAN_ROLE_ARN }}
           NPTG_BUCKET_KEY: ${{ vars.NPTG_BUCKET_KEY }}
+          NOC_BUCKET_NAME: ${{ vars.NOC_BUCKET_NAME }}
+          NOC_BUCKET_REGION: ${{ vars.NOC_BUCKET_REGION }}
+          NOC_BUCKET_KEY: ${{ vars.NOC_BUCKET_KEY }}
+          NOC_ROLE_ARN: ${{ vars.NOC_ROLE_ARN }}
         run: |
           pnpm run deploy --stage prod
 

--- a/packages/ref-data-csv-uploader/index.ts
+++ b/packages/ref-data-csv-uploader/index.ts
@@ -12,6 +12,27 @@ import { parse } from "papaparse";
 const dbClient = getDbClient();
 const fileNames = ["Stops.csv", "NOCLines.csv", "NOCTable.csv", "PublicName.csv"];
 const region = process.env.AWS_REGION;
+const nocKeyByFileName: Partial<Record<(typeof fileNames)[number], string>> = {
+    "NOCLines.csv": "table_noclines_latest_csv.csv",
+    "NOCTable.csv": "table_noc_table_latest_csv.csv",
+    "PublicName.csv": "table_public_name_latest_csv.csv",
+};
+
+const getNocObjectKey = (fileName: string, nocBucketKeyPrefix?: string) => {
+    const nocFileKey = nocKeyByFileName[fileName as (typeof fileNames)[number]];
+
+    if (!nocFileKey) {
+        return undefined;
+    }
+
+    if (!nocBucketKeyPrefix) {
+        return nocFileKey;
+    }
+
+    const normalisedPrefix = nocBucketKeyPrefix.endsWith("/") ? nocBucketKeyPrefix.slice(0, -1) : nocBucketKeyPrefix;
+
+    return `${normalisedPrefix}/${nocFileKey}`;
+};
 
 const getSourceS3Client = (roleArn?: string) => {
     if (!roleArn) {
@@ -166,6 +187,10 @@ export const main: Handler = async (event, context) => {
             SST_Parameter_value_NAPTAN_ROLE_ARN: sstLegacyNaptanRoleArn,
             NAPTAN_BUCKET_NAME: naptanBucketName,
             NAPTAN_BUCKET_KEY: naptanBucketKey,
+            NOC_ROLE_ARN: legacyNOCRoleArn,
+            SST_Parameter_value_NOC_ROLE_ARN: sstLegacyNOCRoleArn,
+            NOC_BUCKET_NAME: nocBucketName,
+            NOC_BUCKET_KEY: nocBucketKey,
         } = process.env;
 
         if (!csvBucketName) {
@@ -181,12 +206,17 @@ export const main: Handler = async (event, context) => {
             throw new Error("Missing env vars - NAPTAN_BUCKET_NAME must be set when NAPTAN_BUCKET_KEY is provided");
         }
 
-        const roleArn = sourceRoleArn ?? sstSourceRoleArn ?? legacyNaptanRoleArn ?? sstLegacyNaptanRoleArn;
+        // NOC key prefix can optionally be provided, but cannot exist without the bucket name
+        if (nocBucketKey && !nocBucketName) {
+            throw new Error("Missing env vars - NOC_BUCKET_NAME must be set when NOC_BUCKET_KEY is provided");
+        }
+        
+        const roleArn = sourceRoleArn ?? sstSourceRoleArn ?? legacyNaptanRoleArn ?? sstLegacyNaptanRoleArn ?? legacyNOCRoleArn ?? sstLegacyNOCRoleArn;
 
-        // cross-account role assumption is mandatory
-        if (naptanBucketName && !roleArn) {
+        // cross-account role assumption is mandatory for external source buckets
+        if ((naptanBucketName || nocBucketName) && !roleArn) {
             throw new Error(
-                "Missing env vars - SOURCE_ROLE_ARN or NAPTAN_ROLE_ARN must be set when NAPTAN_BUCKET_NAME is provided",
+                "Missing env vars - SOURCE_ROLE_ARN, NAPTAN_ROLE_ARN or NOC_ROLE_ARN must be set when using NAPTAN_BUCKET_NAME or NOC_BUCKET_NAME",
             );
         }
 
@@ -194,6 +224,19 @@ export const main: Handler = async (event, context) => {
             if (fileName === "Stops.csv" && naptanBucketName && naptanBucketKey) {
                 logger.info(`Using external NaPTAN bucket: ${naptanBucketName}/${naptanBucketKey}`);
                 await processFile("Stops.csv", naptanBucketName, naptanBucketKey, roleArn);
+            } else if (
+                ["NOCLines.csv", "NOCTable.csv", "PublicName.csv"].includes(fileName) &&
+                nocBucketName
+            ) {
+                const nocObjectKey = getNocObjectKey(fileName, nocBucketKey);
+
+                if (!nocObjectKey) {
+                    await processFile(fileName, csvBucketName);
+                    continue;
+                }
+
+                logger.info(`Using external NOC bucket: ${nocBucketName}/${nocObjectKey} for ${fileName}`);
+                await processFile(fileName, nocBucketName, nocObjectKey, roleArn);
             } else {
                 await processFile(fileName, csvBucketName);
             }

--- a/stacks/RefDataStepFunctionStack.ts
+++ b/stacks/RefDataStepFunctionStack.ts
@@ -50,6 +50,19 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
         value: process.env.NPTG_ROLE_ARN ?? process.env.NAPTAN_ROLE_ARN ?? "",
     });
 
+    const nocBucketName = new Config.Parameter(stack, "NOC_BUCKET_NAME", {
+        value: process.env.NOC_BUCKET_NAME ?? "",
+    });
+    const nocBucketRegion = new Config.Parameter(stack, "NOC_BUCKET_REGION", {
+        value: process.env.NOC_BUCKET_REGION ?? "",
+    });
+    const nocBucketKey = new Config.Parameter(stack, "NOC_BUCKET_KEY", {
+        value: process.env.NOC_BUCKET_KEY ?? "",
+    });
+    const nocRoleArn = new Config.Parameter(stack, "NOC_ROLE_ARN", {
+        value: process.env.NOC_ROLE_ARN ?? "",
+    });
+
     const csvBucket = createBucket(stack, "cdd-ref-csv-data", false);
     const txcBucket = createBucket(stack, "cdd-ref-txc-data", false, [{ enabled: true, expiration: Duration.days(5) }]);
     const txcZippedBucket = createBucket(stack, "cdd-ref-txc-zipped-data", false, [

--- a/stacks/RefDataStepFunctionStack.ts
+++ b/stacks/RefDataStepFunctionStack.ts
@@ -105,7 +105,7 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
           })
         : undefined;
 
-    const nocRetrieverTask = new LambdaInvoke(stack, "cdd-noc-retriever-task", {
+    const _nocRetrieverTask = new LambdaInvoke(stack, "cdd-noc-retriever-task", {
         stateName: "Retrieve NOC Data",
         lambdaFunction: new Function(stack, "cdd-noc-retriever-function", {
             functionName: `cdd-noc-retriever-${stack.stage}`,
@@ -346,6 +346,10 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
                 naptanBucketRegion,
                 naptanBucketKey,
                 naptanRoleArn,
+                nocBucketName,
+                nocBucketRegion,
+                nocBucketKey,
+                nocRoleArn,
             ],
             vpc,
             vpcSubnets: {
@@ -365,6 +369,9 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
                 NAPTAN_BUCKET_NAME: naptanBucketName.value,
                 NAPTAN_BUCKET_REGION: naptanBucketRegion.value,
                 NAPTAN_BUCKET_KEY: naptanBucketKey.value,
+                NOC_BUCKET_NAME: nocBucketName.value,
+                NOC_BUCKET_REGION: nocBucketRegion.value,
+                NOC_BUCKET_KEY: nocBucketKey.value,
             },
             permissions: [
                 new PolicyStatement({
@@ -374,6 +381,10 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
                 new PolicyStatement({
                     actions: ["s3:GetObject"],
                     resources: [`arn:aws:s3:::${naptanBucketName.value}/*`],
+                }),
+                new PolicyStatement({
+                    actions: ["s3:GetObject"],
+                    resources: [`arn:aws:s3:::${nocBucketName.value}/*`],
                 }),
                 new PolicyStatement({
                     actions: ["cloudwatch:PutMetricData"],
@@ -570,7 +581,7 @@ export const RefDataStepFunctionStack = ({ stack }: StackContext) => {
     })
         .branch(tndsTxcRetrieverTask)
         .branch(bodsTxcRetrieverTask)
-        .branch(nocRetrieverTask)
+        //.branch(nocRetrieverTask)
         //.branch(naptanRetrieverTask)
         .branch(nptgRetrieverTask)
         .branch(bankHolidaysRetrieverTask);


### PR DESCRIPTION
Updating the code to allow the NOC data to be read from the S3 bucket instead of using the URL. The following files have had changes made to them to allow the NOC data to come from the S3 bucket in BODS:

- .github/workflows/manual-deploy.yml
- .github/workflows/pr-merged.yml
- .github/workflows/release-published.yml
- packages/ref-data-csv-uploader/index.ts
- packages/ref-data-csv-uploader/index.ts
- stacks/RefDataStepFunctionStack.ts